### PR TITLE
feat: Snowflake infra bootstrap + Dagster Cloud deploy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,35 +1,3 @@
-# Data Directories
-DATA_RAW=/Users/cdcoonce/Documents/GitHub/Weather_Adjusted_Generation_Analytics/data/raw
-DATA_INTERMEDIATE=/Users/cdcoonce/Documents/GitHub/Weather_Adjusted_Generation_Analytics/data/intermediate
-DATA_PROCESSED=/Users/cdcoonce/Documents/GitHub/Weather_Adjusted_Generation_Analytics/data/processed
-
-# DuckDB Configuration
-DUCKDB_PATH=/Users/cdcoonce/Documents/GitHub/Weather_Adjusted_Generation_Analytics/data/warehouse.duckdb
-DUCKDB_MEMORY_LIMIT=8GB
-DUCKDB_THREADS=4
-
-# dlt Configuration
-DLT_SCHEMA=renewable_energy
-DLT_PIPELINE_NAME=renewable_ingestion
-DLT_DESTINATION=duckdb
-
-# Mock Data Configuration
-MOCK_START_DATE=2023-01-01
-MOCK_END_DATE=2024-12-31
-MOCK_ASSET_COUNT=10
-MOCK_RANDOM_SEED=42
-
-# dbt Configuration
-DBT_PROFILES_DIR=/Users/cdcoonce/Documents/GitHub/Weather_Adjusted_Generation_Analytics/dbt/renewable_dbt/profiles
-DBT_PROJECT_DIR=/Users/cdcoonce/Documents/GitHub/Weather_Adjusted_Generation_Analytics/dbt/renewable_dbt
-
-# Dagster Configuration
-DAGSTER_HOME=/Users/cdcoonce/Documents/GitHub/Weather_Adjusted_Generation_Analytics/dags/dagster_project
-
-# Logging Configuration
-LOG_LEVEL=INFO
-LOG_FORMAT=json
-
 # ──────────────────────────────────────────────────────────────────────
 # WAGA Snowflake Environment Variables
 # ──────────────────────────────────────────────────────────────────────

--- a/.github/workflows/branch_deployments.yml
+++ b/.github/workflows/branch_deployments.yml
@@ -1,0 +1,117 @@
+name: Serverless Branch Deployments
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, closed]
+
+concurrency:
+  group: ${{ github.ref }}/branch_deployments
+  cancel-in-progress: true
+
+env:
+  DAGSTER_CLOUD_URL: "https://charles-likes-data.dagster.plus"
+  DAGSTER_CLOUD_API_TOKEN: ${{ secrets.DAGSTER_CLOUD_API_TOKEN }}
+  ENABLE_FAST_DEPLOYS: 'true'
+  PYTHON_VERSION: '3.12'
+  DAGSTER_CLOUD_FILE: 'dagster_cloud.yaml'
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  test:
+    name: Run Tests
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install dependencies
+        run: pip install uv && uv sync --extra dev
+      - name: Run tests
+        run: uv run python -m pytest -m unit -q
+
+  dagster_cloud_default_deploy:
+    needs: [test]
+    name: Dagster Serverless Deploy
+    runs-on: ubuntu-22.04
+    outputs:
+      build_info: ${{ steps.parse-workspace.outputs.build_info }}
+
+    steps:
+      - name: Prerun Checks
+        id: prerun
+        uses: dagster-io/dagster-cloud-action/actions/utils/prerun@v1.12.19
+
+      - name: Launch Docker Deploy
+        if: steps.prerun.outputs.result == 'docker-deploy'
+        id: parse-workspace
+        uses: dagster-io/dagster-cloud-action/actions/utils/parse_workspace@v1.12.19
+        with:
+          dagster_cloud_file: $DAGSTER_CLOUD_FILE
+
+      - name: Checkout for Python Executable Deploy
+        if: steps.prerun.outputs.result == 'pex-deploy'
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+          path: project-repo
+
+      - name: Set up Python
+        if: steps.prerun.outputs.result == 'pex-deploy'
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Generate dbt manifest
+        if: steps.prerun.outputs.result == 'pex-deploy'
+        run: |
+          cd project-repo
+          pip install "dbt-core>=1.7,<2" "dbt-snowflake>=1.7,<2"
+          cd dbt/renewable_dbt
+          dbt deps
+          dbt parse --profiles-dir profiles
+        env:
+          WAGA_SNOWFLAKE_ACCOUNT: ${{ secrets.WAGA_SNOWFLAKE_ACCOUNT }}
+          WAGA_SNOWFLAKE_USER: ${{ secrets.WAGA_SNOWFLAKE_USER }}
+          WAGA_SNOWFLAKE_PRIVATE_KEY_BASE64: ${{ secrets.WAGA_SNOWFLAKE_PRIVATE_KEY_BASE64 }}
+          WAGA_SNOWFLAKE_WAREHOUSE: ${{ secrets.WAGA_SNOWFLAKE_WAREHOUSE }}
+          WAGA_SNOWFLAKE_DATABASE: ${{ secrets.WAGA_SNOWFLAKE_DATABASE }}
+          WAGA_SNOWFLAKE_ROLE: ${{ secrets.WAGA_SNOWFLAKE_ROLE }}
+
+      - name: Python Executable Deploy
+        if: steps.prerun.outputs.result == 'pex-deploy'
+        uses: dagster-io/dagster-cloud-action/actions/build_deploy_python_executable@v1.12.19
+        with:
+          dagster_cloud_file: "$GITHUB_WORKSPACE/project-repo/$DAGSTER_CLOUD_FILE"
+          build_output_dir: "$GITHUB_WORKSPACE/build"
+          python_version: "${{ env.PYTHON_VERSION }}"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  dagster_cloud_docker_deploy:
+    name: Docker Deploy
+    runs-on: ubuntu-22.04
+    if: needs.dagster_cloud_default_deploy.outputs.build_info
+    needs: dagster_cloud_default_deploy
+    strategy:
+      fail-fast: false
+      matrix:
+        location: ${{ fromJSON(needs.dagster_cloud_default_deploy.outputs.build_info) }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+      - name: Build and deploy to Dagster Cloud serverless
+        uses: dagster-io/dagster-cloud-action/actions/serverless_branch_deploy@v1.12.19
+        with:
+          dagster_cloud_api_token: ${{ secrets.DAGSTER_CLOUD_API_TOKEN }}
+          location: ${{ toJson(matrix.location) }}
+          base_image: "python:${{ env.PYTHON_VERSION }}-slim"
+          organization_id: ${{ secrets.ORGANIZATION_ID }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,115 @@
+name: Serverless Prod Deployment
+on:
+  push:
+    branches:
+      - "main"
+
+concurrency:
+  group: ${{ github.ref }}/deploy
+  cancel-in-progress: true
+
+env:
+  DAGSTER_CLOUD_URL: "https://charles-likes-data.dagster.plus"
+  DAGSTER_CLOUD_API_TOKEN: ${{ secrets.DAGSTER_CLOUD_API_TOKEN }}
+  ENABLE_FAST_DEPLOYS: 'true'
+  PYTHON_VERSION: '3.12'
+  DAGSTER_CLOUD_FILE: 'dagster_cloud.yaml'
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  test:
+    name: Run Tests
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install dependencies
+        run: pip install uv && uv sync --extra dev
+      - name: Run tests
+        run: uv run python -m pytest -m unit -q
+
+  dagster_cloud_default_deploy:
+    needs: [test]
+    name: Dagster Serverless Deploy
+    runs-on: ubuntu-22.04
+    outputs:
+      build_info: ${{ steps.parse-workspace.outputs.build_info }}
+
+    steps:
+      - name: Prerun Checks
+        id: prerun
+        uses: dagster-io/dagster-cloud-action/actions/utils/prerun@v1.12.19
+
+      - name: Launch Docker Deploy
+        if: steps.prerun.outputs.result == 'docker-deploy'
+        id: parse-workspace
+        uses: dagster-io/dagster-cloud-action/actions/utils/parse_workspace@v1.12.19
+        with:
+          dagster_cloud_file: $DAGSTER_CLOUD_FILE
+
+      - name: Checkout for Python Executable Deploy
+        if: steps.prerun.outputs.result == 'pex-deploy'
+        uses: actions/checkout@v4
+        with:
+          path: project-repo
+
+      - name: Set up Python
+        if: steps.prerun.outputs.result == 'pex-deploy'
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Generate dbt manifest
+        if: steps.prerun.outputs.result == 'pex-deploy'
+        run: |
+          cd project-repo
+          pip install "dbt-core>=1.7,<2" "dbt-snowflake>=1.7,<2"
+          cd dbt/renewable_dbt
+          dbt deps
+          dbt parse --profiles-dir profiles
+        env:
+          WAGA_SNOWFLAKE_ACCOUNT: ${{ secrets.WAGA_SNOWFLAKE_ACCOUNT }}
+          WAGA_SNOWFLAKE_USER: ${{ secrets.WAGA_SNOWFLAKE_USER }}
+          WAGA_SNOWFLAKE_PRIVATE_KEY_BASE64: ${{ secrets.WAGA_SNOWFLAKE_PRIVATE_KEY_BASE64 }}
+          WAGA_SNOWFLAKE_WAREHOUSE: ${{ secrets.WAGA_SNOWFLAKE_WAREHOUSE }}
+          WAGA_SNOWFLAKE_DATABASE: ${{ secrets.WAGA_SNOWFLAKE_DATABASE }}
+          WAGA_SNOWFLAKE_ROLE: ${{ secrets.WAGA_SNOWFLAKE_ROLE }}
+
+      - name: Python Executable Deploy
+        if: steps.prerun.outputs.result == 'pex-deploy'
+        uses: dagster-io/dagster-cloud-action/actions/build_deploy_python_executable@v1.12.19
+        with:
+          dagster_cloud_file: "$GITHUB_WORKSPACE/project-repo/$DAGSTER_CLOUD_FILE"
+          build_output_dir: "$GITHUB_WORKSPACE/build"
+          python_version: "${{ env.PYTHON_VERSION }}"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  dagster_cloud_docker_deploy:
+    name: Docker Deploy
+    runs-on: ubuntu-22.04
+    if: needs.dagster_cloud_default_deploy.outputs.build_info
+    needs: dagster_cloud_default_deploy
+    strategy:
+      fail-fast: false
+      matrix:
+        location: ${{ fromJSON(needs.dagster_cloud_default_deploy.outputs.build_info) }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Build and deploy to Dagster Cloud serverless
+        uses: dagster-io/dagster-cloud-action/actions/serverless_prod_deploy@v1.12.19
+        with:
+          dagster_cloud_api_token: ${{ secrets.DAGSTER_CLOUD_API_TOKEN }}
+          location: ${{ toJson(matrix.location) }}
+          base_image: "python:${{ env.PYTHON_VERSION }}-slim"
+          organization_id: ${{ secrets.ORGANIZATION_ID }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,8 +36,7 @@ Parquet/API sources
   - `models/marts/` — contracted tables
   - `models/semantic_models/` — dbt metrics layer
   - `profiles/profiles.yml` — Snowflake key-pair auth with env var templating
-- `weather_adjusted_generation_analytics/` — **Legacy** package (DuckDB-based, kept for reference)
-- `tests/` — pytest suite (unit tests only; DuckDB integration tests removed)
+- `tests/` — pytest suite (unit tests only)
 
 ### Snowflake Schemas
 
@@ -87,9 +86,14 @@ Parquet/API sources
 - **Empty mart guard**: Analytics assets raise `dagster.Failure` if source mart has fewer than 10 rows.
 - **Merge idempotency**: dlt uses `write_disposition="merge"` on `(asset_id, timestamp)` — running ingestion twice produces no duplicates.
 
-## CI
+## CI / Deployment
 
-GitHub Actions runs lint (ruff) then unit tests on every push/PR to main. No integration test job — Snowflake integration tests will be added when credentials are available in CI.
+- **`ci.yml`** — Lint (ruff) + unit tests on every push/PR to main
+- **`deploy.yml`** — Dagster Cloud serverless prod deploy on push to main (test → dbt manifest → deploy)
+- **`branch_deployments.yml`** — Ephemeral branch deploys on PRs for preview environments
+- **Dagster Cloud org**: `charles-likes-data.dagster.plus`
+- **dbt manifest**: Generated in deploy workflows via `dbt parse` with Snowflake secrets injected
+- **`_ensure_key_file()`**: Decodes `WAGA_SNOWFLAKE_PRIVATE_KEY_BASE64` to temp `.p8` file at runtime for dbt-snowflake
 
 ## Planning
 

--- a/dagster_cloud.yaml
+++ b/dagster_cloud.yaml
@@ -6,4 +6,4 @@ locations:
     build:
       commands:
         - "pip install -e '.[dev]'"
-        - "cd dbt/renewable_dbt && dbt parse"
+        - "cd dbt/renewable_dbt && dbt deps && dbt parse --profiles-dir profiles"

--- a/docs/dev-cycle/snowflake-infra-deploy.state.md
+++ b/docs/dev-cycle/snowflake-infra-deploy.state.md
@@ -1,0 +1,37 @@
+---
+feature: Snowflake Infrastructure & Dagster Cloud Deploy
+slug: snowflake-infra-deploy
+branch: feat/snowflake-infra-deploy
+status: in_progress
+current_phase: implement
+started: 2026-04-05
+---
+
+# Snowflake Infrastructure & Dagster Cloud Deploy — Dev Cycle State
+
+## Artifacts
+
+| Phase       | Artifact            | URL/Path                                                                    |
+| ----------- | ------------------- | --------------------------------------------------------------------------- |
+| Brainstorm  | Design Spec         | `docs/superpowers/specs/2026-04-05-snowflake-infra-deploy-design.md`        |
+| Brainstorm  | PRD Issue           | _skipped — design spec serves as PRD_                                       |
+| Plan        | Plan File           | `docs/plans/snowflake-infra-deploy.md`                                      |
+| CEO Review  | Status              | Complete — approved, no changes                                             |
+| Issues      | Phase 1: Bootstrap  | https://github.com/cdcoonce/Weather-Adjusted-Generation-Analytics/issues/12 |
+| Issues      | Phase 2: dbt_assets | https://github.com/cdcoonce/Weather-Adjusted-Generation-Analytics/issues/13 |
+| Issues      | Phase 3: Deploy     | https://github.com/cdcoonce/Weather-Adjusted-Generation-Analytics/issues/14 |
+| Issues      | Phase 4: Wiring     | https://github.com/cdcoonce/Weather-Adjusted-Generation-Analytics/issues/15 |
+| Implement   | Feature Branch      | `feat/snowflake-infra-deploy`                                               |
+| Code Review | Status              | _pending_                                                                   |
+| PR          | PR URL              | _pending_                                                                   |
+
+## Log
+
+- 2026-04-05: Design spec created and approved through brainstorming session
+- 2026-04-05: Starting Phase 2 — creating implementation plan
+- 2026-04-05: Phase 2 complete — plan written to docs/plans/snowflake-infra-deploy.md
+- 2026-04-05: Starting Phase 3 — CEO review
+- 2026-04-05: Phase 3 complete — plan approved
+- 2026-04-05: Starting Phase 4 — creating GitHub issues
+- 2026-04-05: Phase 4 complete — 4 issues created (#12–#15)
+- 2026-04-05: Starting Phase 5 — implementation

--- a/docs/plans/snowflake-infra-deploy.md
+++ b/docs/plans/snowflake-infra-deploy.md
@@ -1,0 +1,94 @@
+# Plan: Snowflake Infrastructure & Dagster Cloud Deploy
+
+> Source spec: `docs/superpowers/specs/2026-04-05-snowflake-infra-deploy-design.md`
+> Reference implementation: `cdcoonce/Oura-Pipeline`
+
+## Architectural decisions
+
+- **Dagster Cloud action version:** `v1.12.19` (matching Oura Pipeline)
+- **Python version in deploy:** `3.12` (WAGA uses 3.12, Oura uses 3.10)
+- **dbt manifest:** Generated in CI deploy step via `dbt parse`, not committed to git
+- **Key-pair auth:** Base64 PEM in env var, temp `.p8` file at runtime via `_ensure_key_file()`
+- **dbt project loading:** Use `DbtProject` class (like Oura) instead of raw `Path` to manifest — handles `prepare_if_dev()` for local dev
+- **Env var naming:** `WAGA_SNOWFLAKE_*` (differs from Oura's `SNOWFLAKE_*`)
+- **Deploy concurrency:** Cancel in-progress deploys to same branch
+- **Existing CI:** `ci.yml` (lint + unit tests) stays unchanged. Deploy workflows are additive.
+
+---
+
+## Phase 1: Snowflake Bootstrap SQL + Cleanup
+
+### What to build
+
+Create `docs/snowflake/bootstrap.sql` with all Snowflake infrastructure DDL. Clean up `.env.example` to remove DuckDB-era variables. Remove `data/warehouse.duckdb` from disk.
+
+### Acceptance criteria
+
+- [ ] `docs/snowflake/bootstrap.sql` exists with role, warehouse, database, schemas, user, and grants
+- [ ] SQL includes key generation instructions as comments
+- [ ] SQL includes `ALTER USER ... SET RSA_PUBLIC_KEY` placeholder
+- [ ] `.env.example` contains only `WAGA_*` variables (DuckDB section removed)
+- [ ] `data/warehouse.duckdb` deleted from disk
+- [ ] `.gitignore` includes `*.duckdb`
+
+---
+
+## Phase 2: dbt_assets.py — DbtProject + \_ensure_key_file()
+
+### What to build
+
+Rewrite `src/weather_analytics/assets/dbt_assets.py` to use `DbtProject` (like Oura) instead of raw `Path` to manifest. Add `_ensure_key_file()` that decodes `WAGA_SNOWFLAKE_PRIVATE_KEY_BASE64` to a temp `.p8` file and sets `WAGA_SNOWFLAKE_PRIVATE_KEY_PATH`.
+
+### Acceptance criteria
+
+- [ ] `dbt_assets.py` uses `DbtProject(project_dir=..., profiles_dir=...)` and `.manifest_path`
+- [ ] `dbt_assets.py` calls `dbt_project.prepare_if_dev()` for local development
+- [ ] `_ensure_key_file()` decodes base64 env var to temp `.p8` file with `0o600` permissions
+- [ ] `_ensure_key_file()` sets `WAGA_SNOWFLAKE_PRIVATE_KEY_PATH` env var
+- [ ] `_ensure_key_file()` registers `atexit` cleanup
+- [ ] `_ensure_key_file()` is idempotent (skips if path already set)
+- [ ] `_ensure_key_file()` called inside `waga_dbt_assets` before `dbt.cli()`
+- [ ] `definitions.py` updated if imports change
+- [ ] Unit test: `_ensure_key_file()` creates file and sets env var
+- [ ] Unit test: `_ensure_key_file()` is idempotent on second call
+- [ ] Existing dbt_assets tests still pass (or updated for DbtProject pattern)
+
+---
+
+## Phase 3: Deploy Workflows
+
+### What to build
+
+Create `.github/workflows/deploy.yml` (prod) and `.github/workflows/branch_deployments.yml` (PRs) mirroring the Oura Pipeline pattern. Both include test, dbt manifest generation, and Dagster Cloud serverless deploy.
+
+### Acceptance criteria
+
+- [ ] `.github/workflows/deploy.yml` triggers on push to `main`
+- [ ] `.github/workflows/branch_deployments.yml` triggers on PR open/synchronize/reopen/close
+- [ ] Both workflows run unit tests before deploying
+- [ ] Both workflows generate dbt manifest: `dbt deps && dbt parse --profiles-dir .` in `dbt/renewable_dbt/`
+- [ ] dbt manifest step injects `WAGA_SNOWFLAKE_*` from GitHub Secrets
+- [ ] Prod deploy uses `dagster-io/dagster-cloud-action/actions/serverless_prod_deploy@v1.12.19`
+- [ ] Branch deploy uses `dagster-io/dagster-cloud-action/actions/serverless_branch_deploy@v1.12.19`
+- [ ] Both workflows use `DAGSTER_CLOUD_URL: https://charles-likes-data.dagster.plus`
+- [ ] Both workflows use `PYTHON_VERSION: '3.12'`
+- [ ] Both workflows include PEX deploy path with dbt manifest generation
+- [ ] Both workflows include Docker deploy path for serverless
+- [ ] Deploy concurrency configured (cancel in-progress to same branch)
+- [ ] `ORGANIZATION_ID` secret used in Docker deploy step
+
+---
+
+## Phase 4: dagster_cloud.yaml + Final Wiring
+
+### What to build
+
+Verify/update `dagster_cloud.yaml` to ensure the build step works with the deploy workflow. Update CLAUDE.md if needed. Verify the full CI + deploy pipeline configuration is consistent.
+
+### Acceptance criteria
+
+- [ ] `dagster_cloud.yaml` build commands work with the PEX deploy path
+- [ ] `dagster_cloud.yaml` `module_name` matches what `definitions.py` exports
+- [ ] CLAUDE.md updated with deploy workflow information
+- [ ] All unit tests pass: `uv run pytest -m unit -q`
+- [ ] `ruff check src/weather_analytics/` clean

--- a/docs/snowflake/bootstrap.sql
+++ b/docs/snowflake/bootstrap.sql
@@ -1,0 +1,111 @@
+-- =============================================================================
+-- WAGA Snowflake Bootstrap
+-- =============================================================================
+-- Run this script as ACCOUNTADMIN in the Snowflake Web Console.
+-- It creates all infrastructure needed for the WAGA pipeline.
+--
+-- Prerequisites:
+--   1. Generate a key-pair (see Key-Pair Setup section below)
+--   2. Have the public key content ready to paste
+-- =============================================================================
+
+-- -----------------------------------------------------------------------------
+-- 1. Role
+-- -----------------------------------------------------------------------------
+USE ROLE ACCOUNTADMIN;
+
+CREATE ROLE IF NOT EXISTS WAGA_TRANSFORM
+    COMMENT = 'Service role for the WAGA pipeline (Dagster + dbt + dlt)';
+
+-- -----------------------------------------------------------------------------
+-- 2. Warehouse
+-- -----------------------------------------------------------------------------
+CREATE WAREHOUSE IF NOT EXISTS WAGA_WH
+    WAREHOUSE_SIZE = 'XSMALL'
+    AUTO_SUSPEND = 60
+    AUTO_RESUME = TRUE
+    COMMENT = 'Compute warehouse for WAGA pipeline';
+
+-- -----------------------------------------------------------------------------
+-- 3. Database + Schemas
+-- -----------------------------------------------------------------------------
+CREATE DATABASE IF NOT EXISTS WAGA
+    COMMENT = 'Weather Adjusted Generation Analytics';
+
+CREATE SCHEMA IF NOT EXISTS WAGA.RAW
+    COMMENT = 'dlt landing zone (merge disposition)';
+
+CREATE SCHEMA IF NOT EXISTS WAGA.STAGING
+    COMMENT = 'dbt staging views';
+
+CREATE SCHEMA IF NOT EXISTS WAGA.MARTS
+    COMMENT = 'dbt contracted mart tables';
+
+CREATE SCHEMA IF NOT EXISTS WAGA.ANALYTICS
+    COMMENT = 'Polars analytics outputs';
+
+-- -----------------------------------------------------------------------------
+-- 4. Service Account User
+-- -----------------------------------------------------------------------------
+CREATE USER IF NOT EXISTS WAGA_PIPELINE
+    DEFAULT_ROLE = WAGA_TRANSFORM
+    DEFAULT_WAREHOUSE = WAGA_WH
+    COMMENT = 'Service account for WAGA pipeline (key-pair auth, no password)';
+
+-- Paste your public key here after generating it (see below):
+-- ALTER USER WAGA_PIPELINE SET RSA_PUBLIC_KEY = '<paste-public-key-content-here>';
+
+-- -----------------------------------------------------------------------------
+-- 5. Grants
+-- -----------------------------------------------------------------------------
+GRANT USAGE ON WAREHOUSE WAGA_WH TO ROLE WAGA_TRANSFORM;
+
+GRANT USAGE ON DATABASE WAGA TO ROLE WAGA_TRANSFORM;
+GRANT CREATE SCHEMA ON DATABASE WAGA TO ROLE WAGA_TRANSFORM;
+
+GRANT USAGE ON ALL SCHEMAS IN DATABASE WAGA TO ROLE WAGA_TRANSFORM;
+GRANT CREATE TABLE ON ALL SCHEMAS IN DATABASE WAGA TO ROLE WAGA_TRANSFORM;
+GRANT CREATE VIEW ON ALL SCHEMAS IN DATABASE WAGA TO ROLE WAGA_TRANSFORM;
+GRANT SELECT ON ALL TABLES IN DATABASE WAGA TO ROLE WAGA_TRANSFORM;
+GRANT INSERT, UPDATE, DELETE ON ALL TABLES IN DATABASE WAGA TO ROLE WAGA_TRANSFORM;
+
+-- Future grants so new tables/views inherit permissions
+GRANT SELECT ON FUTURE TABLES IN DATABASE WAGA TO ROLE WAGA_TRANSFORM;
+GRANT INSERT, UPDATE, DELETE ON FUTURE TABLES IN DATABASE WAGA TO ROLE WAGA_TRANSFORM;
+GRANT SELECT ON FUTURE VIEWS IN DATABASE WAGA TO ROLE WAGA_TRANSFORM;
+
+GRANT ROLE WAGA_TRANSFORM TO USER WAGA_PIPELINE;
+
+-- =============================================================================
+-- Key-Pair Setup (run locally, NOT in Snowflake)
+-- =============================================================================
+--
+-- 1. Generate RSA private key (PKCS#8, no passphrase):
+--
+--    openssl genrsa 2048 | openssl pkcs8 -topk8 -inform PEM \
+--      -out ~/.snowflake/waga_rsa_key.p8 -nocrypt
+--
+-- 2. Extract the public key:
+--
+--    openssl rsa -in ~/.snowflake/waga_rsa_key.p8 \
+--      -pubout -out ~/.snowflake/waga_rsa_key.pub
+--
+-- 3. Base64-encode the private key for env vars:
+--
+--    base64 -i ~/.snowflake/waga_rsa_key.p8 | tr -d '\n'
+--
+--    -> This value goes into WAGA_SNOWFLAKE_PRIVATE_KEY_BASE64
+--
+-- 4. Set the public key on the Snowflake user:
+--
+--    Copy the content between -----BEGIN PUBLIC KEY----- and
+--    -----END PUBLIC KEY----- (without the markers), paste as a single
+--    line, and run:
+--
+--    ALTER USER WAGA_PIPELINE SET RSA_PUBLIC_KEY = '<single-line-content>';
+--
+-- 5. Verify the key works:
+--
+--    DESC USER WAGA_PIPELINE;
+--    -- RSA_PUBLIC_KEY_FP should show a fingerprint
+-- =============================================================================

--- a/src/weather_analytics/assets/dbt_assets.py
+++ b/src/weather_analytics/assets/dbt_assets.py
@@ -4,28 +4,74 @@ Exposes all dbt models as Dagster software-defined assets so they
 participate in the WAGA asset graph, lineage, and scheduling.
 
 The manifest is generated at build time (``dbt parse`` in the Dagster
-Cloud build step).  When running locally without a manifest (e.g. in
-CI unit tests), the module still imports — but ``waga_dbt_assets`` will
-be ``None`` and must be excluded from ``Definitions``.
+Cloud deploy workflow).  Locally, ``DbtProject.prepare_if_dev()``
+handles manifest generation when running ``dagster dev``.
 """
 
+import atexit
+import base64
+import os
+import tempfile
+from collections.abc import Iterator
 from pathlib import Path
 from typing import Any
 
-DBT_PROJECT_DIR: Path = Path(__file__).resolve().parents[3] / "dbt" / "renewable_dbt"
-DBT_MANIFEST_PATH: Path = DBT_PROJECT_DIR / "target" / "manifest.json"
+from dagster_dbt import DbtProject
 
+DBT_PROJECT_DIR: Path = Path(__file__).resolve().parents[3] / "dbt" / "renewable_dbt"
+
+dbt_project = DbtProject(
+    project_dir=DBT_PROJECT_DIR,
+    profiles_dir=DBT_PROJECT_DIR / "profiles",
+)
+dbt_project.prepare_if_dev()
+
+
+def _ensure_key_file() -> None:
+    """Decode base64 PEM env var to a temp .p8 file for dbt-snowflake.
+
+    ``WAGA_SNOWFLAKE_PRIVATE_KEY_BASE64`` stores base64-encoded PEM, but
+    dbt-snowflake's ``private_key_path`` needs a file on disk.  Writes
+    once per process and sets ``WAGA_SNOWFLAKE_PRIVATE_KEY_PATH`` for
+    ``profiles.yml`` to reference.  The temp file is registered for
+    cleanup on process exit via ``atexit``.
+
+    Idempotent — skips if ``WAGA_SNOWFLAKE_PRIVATE_KEY_PATH`` is already
+    set and the file exists.
+    """
+    existing_path = os.environ.get("WAGA_SNOWFLAKE_PRIVATE_KEY_PATH", "")
+    if existing_path and Path(existing_path).exists():
+        return
+
+    b64_key = os.environ.get("WAGA_SNOWFLAKE_PRIVATE_KEY_BASE64", "")
+    if not b64_key:
+        return
+
+    pem_bytes = base64.b64decode(b64_key)
+    fd, path = tempfile.mkstemp(suffix=".p8")
+    os.write(fd, pem_bytes)
+    os.close(fd)
+    os.chmod(path, 0o600)
+    atexit.register(lambda p: os.unlink(p) if os.path.exists(p) else None, path)
+    os.environ["WAGA_SNOWFLAKE_PRIVATE_KEY_PATH"] = path
+
+
+# Build the dbt assets only when a manifest is available.
+# In CI unit tests the manifest does not exist; waga_dbt_assets will be
+# None and definitions.py filters it out.
 waga_dbt_assets: Any = None
 
-if DBT_MANIFEST_PATH.exists():
+if dbt_project.manifest_path.exists():
     from dagster import AssetExecutionContext
     from dagster_dbt import DbtCliResource, dbt_assets
 
     @dbt_assets(
-        manifest=DBT_MANIFEST_PATH,
+        manifest=dbt_project.manifest_path,
         name="waga_dbt_assets",
     )
-    def waga_dbt_assets(context: AssetExecutionContext, dbt: DbtCliResource) -> None:  # type: ignore[no-redef]
+    def waga_dbt_assets(
+        context: AssetExecutionContext, dbt: DbtCliResource
+    ) -> Iterator:  # type: ignore[no-redef]
         """Materialize all dbt models in the renewable_dbt project.
 
         Parameters
@@ -35,4 +81,5 @@ if DBT_MANIFEST_PATH.exists():
         dbt : DbtCliResource
             Dagster-managed dbt CLI resource.
         """
+        _ensure_key_file()
         yield from dbt.cli(["build"], context=context).stream()

--- a/tests/unit/test_dbt_assets.py
+++ b/tests/unit/test_dbt_assets.py
@@ -9,12 +9,12 @@ from __future__ import annotations
 import pytest
 
 from weather_analytics.assets.dbt_assets import (
-    DBT_MANIFEST_PATH,
     DBT_PROJECT_DIR,
+    dbt_project,
     waga_dbt_assets,
 )
 
-_manifest_missing = not DBT_MANIFEST_PATH.exists()
+_manifest_missing = not dbt_project.manifest_path.exists()
 
 
 @pytest.mark.unit
@@ -34,10 +34,10 @@ class TestDbtAssetsModule:
         assert (DBT_PROJECT_DIR / "dbt_project.yml").is_file()
 
     def test_dbt_manifest_path_structure(self) -> None:
-        """DBT_MANIFEST_PATH has the expected path structure."""
-        assert DBT_MANIFEST_PATH.name == "manifest.json"
-        assert DBT_MANIFEST_PATH.parent.name == "target"
-        assert DBT_MANIFEST_PATH.parent.parent.name == "renewable_dbt"
+        """Manifest path has the expected structure."""
+        manifest_path = dbt_project.manifest_path
+        assert manifest_path.name == "manifest.json"
+        assert "target" in str(manifest_path)
 
     def test_dbt_project_dir_is_absolute(self) -> None:
         """DBT_PROJECT_DIR is an absolute path."""
@@ -65,6 +65,6 @@ class TestDbtAssetsModule:
         _manifest_missing,
         reason="dbt manifest.json not generated (run dbt parse)",
     )
-    def test_waga_dbt_assets_is_none_without_manifest(self) -> None:
+    def test_waga_dbt_assets_is_not_none(self) -> None:
         """When manifest exists, waga_dbt_assets is not None."""
         assert waga_dbt_assets is not None

--- a/tests/unit/test_ensure_key_file.py
+++ b/tests/unit/test_ensure_key_file.py
@@ -1,0 +1,86 @@
+"""Unit tests for _ensure_key_file() in dbt_assets.py."""
+
+from __future__ import annotations
+
+import base64
+import os
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+from weather_analytics.assets.dbt_assets import _ensure_key_file
+
+_FAKE_PEM = (
+    b"-----BEGIN PRIVATE KEY-----\nfake-key-content\n-----END PRIVATE KEY-----\n"
+)
+_FAKE_B64 = base64.b64encode(_FAKE_PEM).decode()
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Ensure key-related env vars are cleaned up after each test.
+
+    _ensure_key_file() writes to os.environ directly, so we need to
+    capture and restore the state ourselves.
+    """
+    orig_path = os.environ.pop("WAGA_SNOWFLAKE_PRIVATE_KEY_PATH", None)
+    orig_b64 = os.environ.pop("WAGA_SNOWFLAKE_PRIVATE_KEY_BASE64", None)
+    yield
+    # Restore original state (or remove if not originally set)
+    if orig_path is not None:
+        os.environ["WAGA_SNOWFLAKE_PRIVATE_KEY_PATH"] = orig_path
+    else:
+        os.environ.pop("WAGA_SNOWFLAKE_PRIVATE_KEY_PATH", None)
+    if orig_b64 is not None:
+        os.environ["WAGA_SNOWFLAKE_PRIVATE_KEY_BASE64"] = orig_b64
+    else:
+        os.environ.pop("WAGA_SNOWFLAKE_PRIVATE_KEY_BASE64", None)
+
+
+@pytest.mark.unit
+def test_creates_file_and_sets_env_var() -> None:
+    """_ensure_key_file decodes base64 to a .p8 file and sets the path env var."""
+    os.environ["WAGA_SNOWFLAKE_PRIVATE_KEY_BASE64"] = _FAKE_B64
+
+    _ensure_key_file()
+
+    path = os.environ.get("WAGA_SNOWFLAKE_PRIVATE_KEY_PATH", "")
+    assert path, "WAGA_SNOWFLAKE_PRIVATE_KEY_PATH should be set"
+    assert Path(path).exists(), "Temp .p8 file should exist"
+    assert Path(path).suffix == ".p8"
+    assert Path(path).read_bytes() == _FAKE_PEM
+
+
+@pytest.mark.unit
+def test_file_has_restrictive_permissions() -> None:
+    """The temp .p8 file should have 0o600 permissions."""
+    os.environ["WAGA_SNOWFLAKE_PRIVATE_KEY_BASE64"] = _FAKE_B64
+
+    _ensure_key_file()
+
+    path = os.environ["WAGA_SNOWFLAKE_PRIVATE_KEY_PATH"]
+    mode = oct(Path(path).stat().st_mode & 0o777)
+    assert mode == "0o600"
+
+
+@pytest.mark.unit
+def test_idempotent_when_path_already_set(tmp_path: Path) -> None:
+    """_ensure_key_file skips if WAGA_SNOWFLAKE_PRIVATE_KEY_PATH already points to a file."""
+    existing_file = tmp_path / "existing.p8"
+    existing_file.write_text("existing-key")
+    os.environ["WAGA_SNOWFLAKE_PRIVATE_KEY_PATH"] = str(existing_file)
+    os.environ["WAGA_SNOWFLAKE_PRIVATE_KEY_BASE64"] = _FAKE_B64
+
+    _ensure_key_file()
+
+    assert os.environ["WAGA_SNOWFLAKE_PRIVATE_KEY_PATH"] == str(existing_file)
+    assert existing_file.read_text() == "existing-key"
+
+
+@pytest.mark.unit
+def test_noop_when_no_base64_env_var() -> None:
+    """_ensure_key_file does nothing when WAGA_SNOWFLAKE_PRIVATE_KEY_BASE64 is not set."""
+    _ensure_key_file()
+
+    assert not os.environ.get("WAGA_SNOWFLAKE_PRIVATE_KEY_PATH")


### PR DESCRIPTION
## Summary

- **Snowflake bootstrap SQL** (`docs/snowflake/bootstrap.sql`) — role, warehouse, database, schemas, service account, grants, key-pair instructions
- **`_ensure_key_file()`** in `dbt_assets.py` — decodes base64 PEM to temp `.p8` file at runtime for dbt-snowflake (mirrors Oura Pipeline pattern)
- **`DbtProject`** replaces raw `Path` manifest loading — enables `prepare_if_dev()` for local development
- **Deploy workflows** — `deploy.yml` (prod on push to main) + `branch_deployments.yml` (PR previews) via `dagster-io/dagster-cloud-action@v1.12.19`
- **Cleanup** — `.env.example` stripped to WAGA-only, `dagster_cloud.yaml` build step updated, CLAUDE.md updated

## Test plan

- [x] 89 unit tests pass, 2 skipped (manifest-dependent)
- [x] `ruff check src/weather_analytics/` clean
- [x] `_ensure_key_file()` tested: creates file, sets env var, idempotent, restrictive permissions
- [ ] Deploy workflow requires GitHub Secrets to be configured before first run

Closes #12, Closes #13, Closes #14, Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)