### PR TITLE
feat: variable multi-technology fleet + portfolio-styled dashboard

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,14 @@ Parquet/API sources
   - `checks/` — freshness, row count, value range asset checks
   - `schedules.py` — daily ingestion, daily dbt, weekly analytics
   - `lib/` — `polars_utils.py` (LazyFrame), `config.py` (Pydantic Settings), `logging.py`
-  - `mock_data/` — weather + generation generators for local dev
+  - `cockpit/` — self-contained static dashboard (Jinja + inline SVG, no chart lib); `build`/`serve`/`deploy` CLI
+  - `mock_data/` — data generators **and** the local fleet simulation:
+    - `fleet.py` — 12-asset mixed fleet (wind/solar/battery/gas) at real US lat/lon
+    - `physics.py` — vectorized plant physics (power curves, SOC dispatch, heat rate)
+    - `weather_sources.py` — Open-Meteo real weather + synthetic fallback
+    - `simulate.py` — weather + physics → hourly generation (merit-order dispatch)
+    - `local_export.py` — build the 4 dashboard JSON files with **no Snowflake**
+    - `generate_generation.py` / `generate_weather.py` — legacy wind/solar generators feeding the Snowflake ingestion path
 - `dbt/renewable_dbt/` — dbt project (dbt-snowflake)
   - `models/staging/{weather,generation}/` — per-source subfolders
   - `models/intermediate/` — ephemeral models
@@ -54,6 +61,8 @@ Parquet/API sources
 - Lint: `uv run ruff check src/weather_analytics/`
 - Format: `uv run ruff format src/weather_analytics/`
 - Type check: `uv run mypy src/weather_analytics/`
+- Rebuild dashboard (no Snowflake): `uv run python scripts/build_local_dashboard.py --start 2025-07-01 --end 2026-06-30 --build` (add `--synthetic` for a deterministic offline run)
+- Preview / deploy dashboard: `uv run python -m weather_analytics.cockpit serve` / `... deploy`
 
 ## Code Style
 
@@ -77,6 +86,8 @@ Parquet/API sources
 - dbt staging organized into per-source subfolders (`weather/`, `generation/`)
 - New data source = new ingestion asset + staging subfolder. Pure additive.
 - dbt manifest generated at build time (`dbt parse`); code handles missing manifest gracefully
+- **Two fleets, on purpose.** The Snowflake ingestion + contracted dbt marts are **wind/solar only** (`ASSET_CONFIGS`; marts infer type from weather correlation, `accepted_values: ['wind','solar']`). The **local simulation** (`mock_data/fleet.py`) is the full **wind/solar/battery/gas** fleet and feeds the dashboard via `local_export.py` — no warehouse. Keep them independent: adding storage/thermal to the local fleet must never touch the contracted marts. Extending the Snowflake path to 4 types is a separate, warehouse-dependent change (branch marts by `asset_type`, widen `accepted_values`, add nullable type-specific columns).
+- Dashboard exports are schema-versioned (`manifest.schema_version`); the local fleet writes **v2.0** (adds battery SOC/throughput + gas fuel/heat-rate/CO₂ columns). `cockpit/data.py` tolerates missing/extra fields so both the Snowflake (v1.0) and local (v2.0) exports render.
 - Ingestion assets use `op_tags={"dagster/concurrency_key": "waga_ingestion"}` to prevent concurrent merges
 
 ## Key Design Decisions

--- a/README.md
+++ b/README.md
@@ -112,6 +112,57 @@ uv run pytest -m unit
 
 ---
 
+## Local Dashboard & Fleet Simulation
+
+The static [cockpit dashboard](https://waga-dashboard.pages.dev) can be rebuilt
+end-to-end **without Snowflake** from a local, physics-based fleet simulation.
+This drives the deployed page and matches the style of the
+[charleslikesdata.com](https://charleslikesdata.com) portfolio.
+
+### The fleet
+
+`src/weather_analytics/mock_data/fleet.py` defines a 12-asset mixed-technology
+fleet at real US sites: **onshore wind** (turbine power curve + air-density
+correction + AR(1) turbulence), **utility solar PV** (NOCT cell-temperature
+derate + inverter clipping + cloud transients), **grid battery storage**
+(SOC-bounded arbitrage dispatch, round-trip losses), and **natural gas** (CCGT +
+peaker, merit-order dispatch, part-load heat rate, forced outages, CO₂).
+
+### Real-time weather
+
+By default the simulation pulls genuine hourly ERA5 weather for each asset's
+latitude/longitude from the free [Open-Meteo archive API](https://open-meteo.com)
+(no API key). If the network is unavailable it falls back to a latitude-aware
+synthetic model, so the pipeline always runs. The dashboard header shows which
+source was used.
+
+### Rebuild the dashboard
+
+```bash
+# Full year of real weather -> exports + rendered dist/index.html
+uv run python scripts/build_local_dashboard.py \
+    --start 2025-07-01 --end 2026-06-30 --build
+
+# Deterministic offline run (synthetic weather)
+uv run python scripts/build_local_dashboard.py \
+    --start 2026-01-01 --end 2026-03-31 --synthetic --build
+
+# Then serve or deploy the static page
+uv run python -m weather_analytics.cockpit serve   # local preview
+uv run python -m weather_analytics.cockpit deploy  # Cloudflare Pages
+```
+
+The four `dashboard_exports/*.json` files (schema v2.0) carry per-technology
+metrics — battery SOC/throughput, gas fuel/heat-rate/CO₂ — alongside the shared
+generation/capacity-factor columns.
+
+> **Scope note:** the mixed fleet is the *local dashboard* dataset. The Snowflake
+> ingestion + contracted dbt marts remain wind/solar-only (they infer asset type
+> from weather correlation); extending those marts to storage/thermal is a
+> separate, warehouse-dependent change.
+
+---
+
 ## Project Structure
 
 ```
@@ -126,7 +177,16 @@ Weather_Adjusted_Generation_Analytics/
 │   ├── checks/                     # Asset checks (freshness, row count, range)
 │   ├── schedules.py                # Daily/weekly schedules
 │   ├── lib/                        # polars_utils, config, logging
-│   └── mock_data/                  # Weather + generation data generators
+│   ├── cockpit/                    # Self-contained static dashboard (build/serve/deploy)
+│   └── mock_data/                  # Fleet simulation + data generators
+│       ├── fleet.py                # 12-asset mixed fleet registry (real US sites)
+│       ├── physics.py              # Wind/solar/battery/gas physics models
+│       ├── weather_sources.py      # Open-Meteo real weather + synthetic fallback
+│       ├── simulate.py             # Weather + physics -> hourly generation
+│       ├── local_export.py         # Build dashboard JSON without Snowflake
+│       └── generate_*.py           # Legacy wind/solar generators (Snowflake path)
+│
+├── scripts/build_local_dashboard.py # Simulate -> export -> render the dashboard
 │
 ├── dbt/renewable_dbt/              # dbt project (dbt-snowflake)
 │   ├── models/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,9 @@ ignore = ["ANN101", "ANN102", "D203", "D213"]
 # CI utility scripts use print() for user-visible log output.
 "scripts/*" = ["T201", "INP001"]
 "src/weather_analytics/cockpit/*" = ["T201"]  # CLI/serve print user-facing output
+# Numerical simulation code: physics functions have legitimately wide
+# signatures (PLR0913) and inline physical constants/thresholds (PLR2004).
+"src/weather_analytics/mock_data/*" = ["PLR0913", "PLR2004"]
 
 [tool.mypy]
 python_version = "3.12"

--- a/scripts/build_local_dashboard.py
+++ b/scripts/build_local_dashboard.py
@@ -1,0 +1,81 @@
+"""Regenerate the WAGA dashboard from a local fleet simulation — no Snowflake.
+
+Runs the multi-technology fleet simulation (wind, solar, battery, gas), writes
+the four ``dashboard_exports/*.json`` files, and (optionally) renders the static
+``dist/index.html`` the cockpit deploys. Real hourly weather is pulled from the
+free Open-Meteo archive API by default, falling back to a physical synthetic
+model when offline.
+
+Examples
+--------
+Regenerate a year of data and build the page::
+
+    python scripts/build_local_dashboard.py --start 2025-07-01 --end 2026-06-30 --build
+
+Deterministic offline run (CI)::
+
+    python scripts/build_local_dashboard.py --start 2026-01-01 --end 2026-03-31 \\
+        --synthetic --build
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from weather_analytics.cockpit.config import DEFAULT_EXPORT_DIR, DEFAULT_OUT
+from weather_analytics.cockpit.data import load_dataset
+from weather_analytics.cockpit.render import render_dashboard
+from weather_analytics.mock_data.local_export import build_local_exports
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Parse args, run the simulation, write exports, optionally render."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--start", default="2025-07-01", help="start date (ISO)")
+    parser.add_argument("--end", default="2026-06-30", help="end date (ISO)")
+    parser.add_argument("--out-dir", default=DEFAULT_EXPORT_DIR)
+    parser.add_argument(
+        "--synthetic",
+        action="store_true",
+        help="force synthetic weather (skip the Open-Meteo pull)",
+    )
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument(
+        "--build",
+        action="store_true",
+        help="also render the static dashboard to dist/index.html",
+    )
+    parser.add_argument("--out", default=DEFAULT_OUT, help="rendered HTML path")
+    args = parser.parse_args(argv)
+
+    start = f"{args.start}T00:00:00" if "T" not in args.start else args.start
+    end = f"{args.end}T23:00:00" if "T" not in args.end else args.end
+
+    print(f"Simulating fleet {start} -> {end} (seed={args.seed}) ...")
+    manifest = build_local_exports(
+        start_date=start,
+        end_date=end,
+        out_dir=Path(args.out_dir),
+        use_real_weather=not args.synthetic,
+        random_seed=args.seed,
+    )
+    print(
+        f"  weather source : {manifest['weather_source']}\n"
+        f"  assets         : {manifest['asset_count']} "
+        f"{manifest['asset_type_counts']}\n"
+        f"  daily rows     : {manifest['row_counts']['daily_performance']}\n"
+        f"  wrote exports  : {args.out_dir}"
+    )
+
+    if args.build:
+        dataset = load_dataset(Path(args.out_dir))
+        render_dashboard(dataset, Path(args.out))
+        print(f"  built dashboard: {args.out}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/weather_analytics/cockpit/charts.py
+++ b/src/weather_analytics/cockpit/charts.py
@@ -3,6 +3,10 @@
 Every function takes the typed Dataset (plus optional asset/date filters) and
 returns plain dicts/lists/strings — never a DataFrame. The client-side app.js
 mirrors this math to redraw on filter changes; keep the two in sync.
+
+The fleet is mixed-technology (wind, solar, battery, gas); helpers here are
+type-aware — batteries are excluded from fleet capacity factor (their net energy
+is negative over a cycle) and each technology gets a stable series color.
 """
 
 from __future__ import annotations
@@ -10,6 +14,26 @@ from __future__ import annotations
 from statistics import fmean
 
 from weather_analytics.cockpit.data import DailyRow, Dataset, WeatherRow
+
+# Technology series colors — echo the portfolio's data-viz palette (green/gold)
+# and extend it with distinct, light-theme-friendly hues for storage and gas.
+TYPE_COLORS: dict[str, str] = {
+    "wind": "#2f6f5f",
+    "solar": "#d4a12e",
+    "battery": "#3f7cac",
+    "gas": "#9c5b3b",
+    "unknown": "#8a8f98",
+}
+
+_RENEWABLE = ("wind", "solar")
+_CF_TYPES = ("wind", "solar", "gas")  # battery CF is not meaningful
+_PRIMARY = "#2f6f5f"  # portfolio data-viz green
+_SECONDARY = "#b0872f"  # portfolio data-viz gold
+
+
+def type_color(asset_type: str) -> str:
+    """Series color for a technology (falls back to a neutral gray)."""
+    return TYPE_COLORS.get(asset_type, TYPE_COLORS["unknown"])
 
 
 def _in_range(date: str, start: str | None, end: str | None) -> bool:
@@ -46,38 +70,73 @@ def filter_weather(
     ]
 
 
+def _type_by_id(dataset: Dataset) -> dict[str, str]:
+    return {a.asset_id: a.asset_type for a in dataset.assets}
+
+
 def fleet_kpis(
     dataset: Dataset,
     asset_ids: set[str] | None = None,
     start: str | None = None,
     end: str | None = None,
 ) -> list[dict]:
+    """Six headline fleet metrics for the KPI strip."""
     daily = filter_daily(dataset.daily, asset_ids, start, end)
-    weather = filter_weather(dataset.weather, asset_ids, start, end)
+    type_of = _type_by_id(dataset)
+
+    def _type(r: DailyRow) -> str:
+        return r.asset_type or type_of.get(r.asset_id, "")
+
     net_gen = sum(r.total_net_generation_mwh for r in daily)
     curtailment = sum(r.total_curtailment_mwh for r in daily)
-    cf = fmean([r.daily_capacity_factor for r in daily]) if daily else 0.0
-    perf = fmean([r.performance_score for r in weather]) if weather else 0.0
+    co2 = sum(r.total_co2_tonnes for r in daily)
+    battery_throughput = sum(
+        r.total_discharge_mwh for r in daily if _type(r) == "battery"
+    )
+    renewable_gen = sum(
+        r.total_net_generation_mwh for r in daily if _type(r) in _RENEWABLE
+    )
+    served = sum(r.total_net_generation_mwh for r in daily if _type(r) in _CF_TYPES)
+    cf_rows = [r.daily_capacity_factor for r in daily if _type(r) in _CF_TYPES]
+    cf = fmean(cf_rows) if cf_rows else 0.0
+    renewable_share = (renewable_gen / served * 100.0) if served > 0 else 0.0
+
     return [
+        {
+            "key": "net_generation",
+            "label": "net generation",
+            "value": f"{net_gen:,.0f}",
+            "unit": "MWh",
+        },
         {
             "key": "capacity_factor",
             "label": "fleet capacity factor",
             "value": f"{cf * 100:.1f}%",
+            "unit": "wind · solar · gas",
         },
         {
-            "key": "net_generation",
-            "label": "net generation (MWh)",
-            "value": f"{net_gen:,.0f}",
+            "key": "renewable_share",
+            "label": "renewable share",
+            "value": f"{renewable_share:.0f}%",
+            "unit": "of served load",
         },
         {
-            "key": "performance_score",
-            "label": "avg weather-adj. score",
-            "value": f"{perf:.2f}",
+            "key": "co2_emissions",
+            "label": "CO₂ emissions",
+            "value": f"{co2:,.0f}",
+            "unit": "tonnes",
+        },
+        {
+            "key": "battery_throughput",
+            "label": "battery discharge",
+            "value": f"{battery_throughput:,.0f}",
+            "unit": "MWh delivered",
         },
         {
             "key": "curtailment",
-            "label": "curtailment (MWh)",
+            "label": "curtailment",
             "value": f"{curtailment:,.0f}",
+            "unit": "MWh",
         },
     ]
 
@@ -87,26 +146,30 @@ def line_series(
     width: int = 720,
     height: int = 200,
     pad: int = 8,
+    color: str = "var(--accent)",
 ) -> dict | None:
     """Turn ordered (date, value) pairs into SVG polyline + filled-area geometry."""
     if not pairs:
         return None
     values = [v for _, v in pairs]
-    y_max = max(values) or 1.0
+    y_min = min([0.0, *values])
+    y_max = max(values)
+    span = (y_max - y_min) or 1.0
     n = len(pairs)
 
     def x(i: int) -> float:
         return pad + (i / (n - 1) * (width - 2 * pad) if n > 1 else 0.0)
 
     def y(v: float) -> float:
-        return height - pad - (v / y_max) * (height - 2 * pad)
+        return height - pad - ((v - y_min) / span) * (height - 2 * pad)
 
+    baseline = y(0.0)
     pts = [(x(i), y(v)) for i, v in enumerate(values)]
     polyline = " ".join(f"{px:.1f},{py:.1f}" for px, py in pts)
     area = (
-        f"M {pts[0][0]:.1f} {height - pad:.1f} "
+        f"M {pts[0][0]:.1f} {baseline:.1f} "
         + " ".join(f"L {px:.1f} {py:.1f}" for px, py in pts)
-        + f" L {pts[-1][0]:.1f} {height - pad:.1f} Z"
+        + f" L {pts[-1][0]:.1f} {baseline:.1f} Z"
     )
     return {
         "width": width,
@@ -114,15 +177,25 @@ def line_series(
         "pad": pad,
         "area_path": area,
         "polyline": polyline,
+        "color": color,
         "y_max": y_max,
         "x0_label": pairs[0][0],
         "x1_label": pairs[-1][0],
     }
 
 
-def _by_date_sum(rows: list[DailyRow], attr: str) -> list[tuple[str, float]]:
+def _by_date_sum(
+    rows: list[DailyRow],
+    attr: str,
+    types: tuple[str, ...] | None = None,
+    type_of: dict[str, str] | None = None,
+) -> list[tuple[str, float]]:
     acc: dict[str, float] = {}
     for r in rows:
+        if types is not None:
+            t = r.asset_type or (type_of or {}).get(r.asset_id, "")
+            if t not in types:
+                continue
         acc[r.date] = acc.get(r.date, 0.0) + getattr(r, attr)
     return sorted(acc.items())
 
@@ -141,7 +214,7 @@ def generation_series(
     end: str | None = None,
 ) -> dict | None:
     daily = filter_daily(dataset.daily, asset_ids, start, end)
-    return line_series(_by_date_sum(daily, "total_net_generation_mwh"))
+    return line_series(_by_date_sum(daily, "total_net_generation_mwh"), color=_PRIMARY)
 
 
 def capacity_factor_series(
@@ -151,8 +224,13 @@ def capacity_factor_series(
     end: str | None = None,
 ) -> dict | None:
     daily = filter_daily(dataset.daily, asset_ids, start, end)
-    pairs = _by_date_mean([(r.date, r.daily_capacity_factor) for r in daily])
-    return line_series(pairs, height=160)
+    type_of = _type_by_id(dataset)
+    cf_rows = [
+        (r.date, r.daily_capacity_factor)
+        for r in daily
+        if (r.asset_type or type_of.get(r.asset_id, "")) in _CF_TYPES
+    ]
+    return line_series(_by_date_mean(cf_rows), height=160, color=_PRIMARY)
 
 
 def performance_series(
@@ -163,7 +241,40 @@ def performance_series(
 ) -> dict | None:
     weather = filter_weather(dataset.weather, asset_ids, start, end)
     pairs = _by_date_mean([(r.date, r.performance_score) for r in weather])
-    return line_series(pairs, height=160)
+    return line_series(pairs, height=160, color=_SECONDARY)
+
+
+def battery_soc_series(
+    dataset: Dataset,
+    asset_ids: set[str] | None = None,
+    start: str | None = None,
+    end: str | None = None,
+) -> dict | None:
+    """Mean battery state-of-charge (%) over time."""
+    daily = filter_daily(dataset.daily, asset_ids, start, end)
+    type_of = _type_by_id(dataset)
+    pairs = _by_date_mean(
+        [
+            (r.date, r.avg_soc_pct)
+            for r in daily
+            if (r.asset_type or type_of.get(r.asset_id, "")) == "battery"
+            and r.avg_soc_pct is not None
+        ]
+    )
+    return line_series(pairs, height=160, color=TYPE_COLORS["battery"])
+
+
+def emissions_series(
+    dataset: Dataset,
+    asset_ids: set[str] | None = None,
+    start: str | None = None,
+    end: str | None = None,
+) -> dict | None:
+    """Total gas CO₂ emissions (tonnes) over time."""
+    daily = filter_daily(dataset.daily, asset_ids, start, end)
+    type_of = _type_by_id(dataset)
+    pairs = _by_date_sum(daily, "total_co2_tonnes", ("gas",), type_of)
+    return line_series(pairs, height=160, color=TYPE_COLORS["gas"])
 
 
 def _hbars(
@@ -190,12 +301,21 @@ def asset_bars(
     end: str | None = None,
 ) -> list[dict]:
     daily = filter_daily(dataset.daily, asset_ids, start, end)
-    type_by_id = {a.asset_id: a.asset_type for a in dataset.assets}
+    type_by_id = _type_by_id(dataset)
+    name_by_id = {a.asset_id: a.display_name for a in dataset.assets}
+    # Batteries have near-zero/negative CF; show them by throughput utilization.
     groups: dict[str, list[float]] = {}
     for r in daily:
         groups.setdefault(r.asset_id, []).append(r.daily_capacity_factor)
     means = sorted((aid, fmean(vs)) for aid, vs in groups.items())
-    extra = {aid: {"asset_type": type_by_id.get(aid, "")} for aid, _ in means}
+    extra = {
+        aid: {
+            "asset_type": type_by_id.get(aid, ""),
+            "color": type_color(type_by_id.get(aid, "")),
+            "name": name_by_id.get(aid, aid),
+        }
+        for aid, _ in means
+    }
     return _hbars(means, extra)
 
 
@@ -206,9 +326,10 @@ def type_split(
     end: str | None = None,
 ) -> list[dict]:
     daily = filter_daily(dataset.daily, asset_ids, start, end)
-    type_by_id = {a.asset_id: a.asset_type for a in dataset.assets}
+    type_by_id = _type_by_id(dataset)
     totals: dict[str, float] = {}
     for r in daily:
-        t = type_by_id.get(r.asset_id, "unknown")
+        t = r.asset_type or type_by_id.get(r.asset_id, "unknown")
         totals[t] = totals.get(t, 0.0) + r.total_net_generation_mwh
-    return _hbars(sorted(totals.items()))
+    extra = {t: {"color": type_color(t)} for t in totals}
+    return _hbars(sorted(totals.items()), extra)

--- a/src/weather_analytics/cockpit/data.py
+++ b/src/weather_analytics/cockpit/data.py
@@ -19,6 +19,7 @@ class Asset:
     size_category: str
     asset_type: str
     display_name: str
+    region: str = ""
 
 
 @dataclass(frozen=True)
@@ -30,6 +31,11 @@ class DailyRow:
     avg_availability_pct: float
     total_curtailment_mwh: float
     daily_performance_rating: str
+    asset_type: str = ""
+    total_discharge_mwh: float = 0.0
+    avg_soc_pct: float | None = None
+    total_co2_tonnes: float = 0.0
+    total_fuel_mmbtu: float = 0.0
 
 
 @dataclass(frozen=True)
@@ -48,6 +54,7 @@ class Manifest:
     date_range_end: str
     asset_count: int
     schema_version: str
+    weather_source: str = ""
 
 
 @dataclass(frozen=True)
@@ -88,6 +95,7 @@ def load_dataset(export_dir: Path) -> Dataset:
         date_range_end=str(date_range.get("end", "")),
         asset_count=int(manifest_raw.get("asset_count", 0)),
         schema_version=str(manifest_raw.get("schema_version", "")),
+        weather_source=str(manifest_raw.get("weather_source", "")),
     )
 
     assets = [
@@ -97,6 +105,7 @@ def load_dataset(export_dir: Path) -> Dataset:
             size_category=str(a.get("size_category", "")),
             asset_type=str(a.get("asset_type", "")),
             display_name=str(a.get("display_name", a.get("asset_id", ""))),
+            region=str(a.get("region", "")),
         )
         for a in assets_raw
     ]
@@ -110,6 +119,13 @@ def load_dataset(export_dir: Path) -> Dataset:
             avg_availability_pct=_num(r.get("avg_availability_pct")),
             total_curtailment_mwh=_num(r.get("total_curtailment_mwh")),
             daily_performance_rating=str(r.get("daily_performance_rating", "")),
+            asset_type=str(r.get("asset_type", "")),
+            total_discharge_mwh=_num(r.get("total_discharge_mwh")),
+            avg_soc_pct=(
+                None if r.get("avg_soc_pct") is None else _num(r.get("avg_soc_pct"))
+            ),
+            total_co2_tonnes=_num(r.get("total_co2_tonnes")),
+            total_fuel_mmbtu=_num(r.get("total_fuel_mmbtu")),
         )
         for r in daily_raw
     ]

--- a/src/weather_analytics/cockpit/render.py
+++ b/src/weather_analytics/cockpit/render.py
@@ -50,6 +50,8 @@ def render_dashboard(
         "generation": _safe(lambda: charts.generation_series(dataset), None),
         "capacity_factor": _safe(lambda: charts.capacity_factor_series(dataset), None),
         "performance": _safe(lambda: charts.performance_series(dataset), None),
+        "battery_soc": _safe(lambda: charts.battery_soc_series(dataset), None),
+        "emissions": _safe(lambda: charts.emissions_series(dataset), None),
         "asset_bars": _safe(lambda: charts.asset_bars(dataset), []),
         "type_split": _safe(lambda: charts.type_split(dataset), []),
         "assets": dataset.assets,

--- a/src/weather_analytics/cockpit/static/app.js
+++ b/src/weather_analytics/cockpit/static/app.js
@@ -1,7 +1,8 @@
 /* src/weather_analytics/cockpit/static/app.js
-   Light client-side interactivity. Reads the JSON island and, on filter change,
-   recomputes KPIs and redraws the SVG line charts + hbars. The aggregation math
-   mirrors weather_analytics.cockpit.charts (keep them in sync). */
+   Client-side interactivity for the WAGA cockpit. Reads the JSON island and, on
+   load and on every filter change, recomputes KPIs and redraws the SVG charts,
+   technology bars, battery/gas series, and the fleet roster. The aggregation
+   math mirrors weather_analytics.cockpit.charts (keep them in sync). */
 (function () {
   "use strict";
   var el = document.getElementById("cockpit-data");
@@ -10,8 +11,24 @@
   var assets = D.assets || [];
   var daily = D.daily || [];
   var weather = D.weather || [];
-  var typeById = {};
-  assets.forEach(function (a) { typeById[a.asset_id] = a.asset_type; });
+
+  var TYPE_COLORS = {
+    wind: "#2f6f5f", solar: "#d4a12e", battery: "#3f7cac",
+    gas: "#9c5b3b", unknown: "#8a8f98",
+  };
+  var PRIMARY = "#2f6f5f", GOLD = "#b0872f";
+  var RENEWABLE = { wind: 1, solar: 1 };
+  var CF_TYPES = { wind: 1, solar: 1, gas: 1 };
+
+  var typeById = {}, nameById = {}, capById = {}, regionById = {};
+  assets.forEach(function (a) {
+    typeById[a.asset_id] = a.asset_type;
+    nameById[a.asset_id] = a.display_name || a.asset_id;
+    capById[a.asset_id] = +a.capacity_mw || 0;
+    regionById[a.asset_id] = a.region || "";
+  });
+  function typeOf(id) { return typeById[id] || "unknown"; }
+  function colorFor(t) { return TYPE_COLORS[t] || TYPE_COLORS.unknown; }
 
   var fType = document.getElementById("f-type");
   var fAsset = document.getElementById("f-asset");
@@ -19,6 +36,9 @@
   var fEnd = document.getElementById("f-end");
 
   function num(v) { return v === null || v === undefined || isNaN(+v) ? 0 : +v; }
+  function fmt(n, dp) {
+    return n.toLocaleString("en-US", { minimumFractionDigits: dp, maximumFractionDigits: dp });
+  }
 
   function allowedIds() {
     var t = fType.value, a = fAsset.value;
@@ -27,77 +47,137 @@
       .map(function (x) { return x.asset_id; });
     return new Set(ids);
   }
-
   function inRange(d) {
     var s = fStart.value, e = fEnd.value;
     if (s && d < s) return false;
     if (e && d > e) return false;
     return true;
   }
-
   function filt(rows, ids) {
     return rows.filter(function (r) { return ids.has(r.asset_id) && inRange(r.date); });
   }
 
-  function fmt(n, dp) { return n.toLocaleString("en-US", { minimumFractionDigits: dp, maximumFractionDigits: dp }); }
-
-  function setKpis(fd, fw) {
-    var netGen = 0, curt = 0, cfSum = 0, perfSum = 0;
-    fd.forEach(function (r) { netGen += num(r.total_net_generation_mwh); curt += num(r.total_curtailment_mwh); cfSum += num(r.daily_capacity_factor); });
-    fw.forEach(function (r) { perfSum += num(r.performance_score); });
-    var cf = fd.length ? cfSum / fd.length : 0;
-    var perf = fw.length ? perfSum / fw.length : 0;
-    put("capacity_factor", fmt(cf * 100, 1) + "%");
+  /* ---- KPIs ---- */
+  function setKpis(fd) {
+    var netGen = 0, curt = 0, co2 = 0, batt = 0, renGen = 0, served = 0;
+    var cfSum = 0, cfN = 0;
+    fd.forEach(function (r) {
+      var t = r.asset_type || typeOf(r.asset_id);
+      netGen += num(r.total_net_generation_mwh);
+      curt += num(r.total_curtailment_mwh);
+      co2 += num(r.total_co2_tonnes);
+      if (t === "battery") batt += num(r.total_discharge_mwh);
+      if (RENEWABLE[t]) renGen += num(r.total_net_generation_mwh);
+      if (CF_TYPES[t]) { served += num(r.total_net_generation_mwh); cfSum += num(r.daily_capacity_factor); cfN++; }
+    });
     put("net_generation", fmt(netGen, 0));
-    put("performance_score", fmt(perf, 2));
+    put("capacity_factor", fmt(cfN ? (cfSum / cfN) * 100 : 0, 1) + "%");
+    put("renewable_share", fmt(served > 0 ? (renGen / served) * 100 : 0, 0) + "%");
+    put("co2_emissions", fmt(co2, 0));
+    put("battery_throughput", fmt(batt, 0));
     put("curtailment", fmt(curt, 0));
   }
-
   function put(key, val) {
     var n = document.querySelector('[data-kpi="' + key + '"]');
     if (n) n.textContent = val;
   }
 
-  function byDateSum(rows, attr) {
+  /* ---- aggregation helpers ---- */
+  function byDateSum(rows, attr, typeFilter) {
     var acc = {};
-    rows.forEach(function (r) { acc[r.date] = (acc[r.date] || 0) + num(r[attr]); });
+    rows.forEach(function (r) {
+      if (typeFilter && !typeFilter[r.asset_type || typeOf(r.asset_id)]) return;
+      acc[r.date] = (acc[r.date] || 0) + num(r[attr]);
+    });
     return Object.keys(acc).sort().map(function (d) { return [d, acc[d]]; });
   }
-
-  function byDateMean(rows, attr) {
+  function byDateMean(rows, attr, typeFilter, valid) {
     var g = {};
-    rows.forEach(function (r) { (g[r.date] = g[r.date] || []).push(num(r[attr])); });
+    rows.forEach(function (r) {
+      if (typeFilter && !typeFilter[r.asset_type || typeOf(r.asset_id)]) return;
+      if (valid && (r[attr] === null || r[attr] === undefined)) return;
+      (g[r.date] = g[r.date] || []).push(num(r[attr]));
+    });
     return Object.keys(g).sort().map(function (d) {
       var a = g[d]; return [d, a.reduce(function (s, v) { return s + v; }, 0) / a.length];
     });
   }
 
-  function lineSvg(pairs, width, height, pad) {
+  /* ---- SVG line ---- */
+  function lineSvg(pairs, width, height, color) {
     if (!pairs.length) return '<div class="nodata">no data in range</div>';
-    var yMax = Math.max.apply(null, pairs.map(function (p) { return p[1]; })) || 1;
-    var n = pairs.length;
+    var vals = pairs.map(function (p) { return p[1]; });
+    var yMin = Math.min.apply(null, vals.concat(0));
+    var yMax = Math.max.apply(null, vals);
+    var span = (yMax - yMin) || 1, pad = 8, n = pairs.length;
     function x(i) { return pad + (n > 1 ? (i / (n - 1)) * (width - 2 * pad) : 0); }
-    function y(v) { return height - pad - (v / yMax) * (height - 2 * pad); }
+    function y(v) { return height - pad - ((v - yMin) / span) * (height - 2 * pad); }
+    var base = y(0);
     var pts = pairs.map(function (p, i) { return [x(i), y(p[1])]; });
     var poly = pts.map(function (p) { return p[0].toFixed(1) + "," + p[1].toFixed(1); }).join(" ");
-    var area = "M " + pts[0][0].toFixed(1) + " " + (height - pad).toFixed(1) + " " +
+    var area = "M " + pts[0][0].toFixed(1) + " " + base.toFixed(1) + " " +
       pts.map(function (p) { return "L " + p[0].toFixed(1) + " " + p[1].toFixed(1); }).join(" ") +
-      " L " + pts[n - 1][0].toFixed(1) + " " + (height - pad).toFixed(1) + " Z";
+      " L " + pts[n - 1][0].toFixed(1) + " " + base.toFixed(1) + " Z";
     return '<svg viewBox="0 0 ' + width + ' ' + height + '" preserveAspectRatio="none" role="img">' +
-      '<path d="' + area + '" fill="rgba(90,169,230,0.20)" />' +
-      '<polyline points="' + poly + '" fill="none" stroke="var(--accent)" stroke-width="2" /></svg>' +
-      '<div class="axis"><span>' + pairs[0][0] + '</span><span>max ' + yMax.toFixed(2) +
+      '<path d="' + area + '" fill="' + color + '" fill-opacity="0.12" />' +
+      '<polyline points="' + poly + '" fill="none" stroke="' + color + '" stroke-width="2" /></svg>' +
+      '<div class="axis"><span>' + pairs[0][0] + '</span><span>peak ' + yMax.toFixed(2) +
       '</span><span>' + pairs[n - 1][0] + '</span></div>';
   }
 
-  function hbars(rows, showType) {
+  /* ---- stacked-area generation mix by technology ---- */
+  function stackedMix(fd, width, height) {
+    var order = ["wind", "solar", "gas", "battery"];
+    var dates = {};
+    fd.forEach(function (r) { dates[r.date] = 1; });
+    var dateList = Object.keys(dates).sort();
+    if (!dateList.length) return '<div class="nodata">no data in range</div>';
+    var dIdx = {}; dateList.forEach(function (d, i) { dIdx[d] = i; });
+    var series = {};
+    order.forEach(function (t) { series[t] = new Array(dateList.length).fill(0); });
+    fd.forEach(function (r) {
+      var t = r.asset_type || typeOf(r.asset_id);
+      if (!series[t]) return;
+      var contrib = t === "battery" ? num(r.total_discharge_mwh)
+        : Math.max(0, num(r.total_net_generation_mwh));
+      series[t][dIdx[r.date]] += contrib;
+    });
+    var present = order.filter(function (t) {
+      return series[t].some(function (v) { return v > 0; });
+    });
+    if (!present.length) return '<div class="nodata">no data in range</div>';
+    var totals = dateList.map(function (_, i) {
+      return present.reduce(function (s, t) { return s + series[t][i]; }, 0);
+    });
+    var yMax = Math.max.apply(null, totals) || 1;
+    var pad = 8, n = dateList.length;
+    function x(i) { return pad + (n > 1 ? (i / (n - 1)) * (width - 2 * pad) : 0); }
+    function y(v) { return height - pad - (v / yMax) * (height - 2 * pad); }
+    var cum = new Array(n).fill(0);
+    var paths = "";
+    present.forEach(function (t) {
+      var lower = cum.slice();
+      var upper = cum.map(function (c, i) { return c + series[t][i]; });
+      cum = upper;
+      var top = upper.map(function (v, i) { return "L " + x(i).toFixed(1) + " " + y(v).toFixed(1); }).join(" ");
+      var bot = lower.map(function (v, i) { return "L " + x(i).toFixed(1) + " " + y(v).toFixed(1); }).reverse().join(" ");
+      var d = "M " + x(0).toFixed(1) + " " + y(lower[0]).toFixed(1) + " " + top + " " + bot + " Z";
+      paths += '<path d="' + d + '" fill="' + colorFor(t) + '" fill-opacity="0.85" />';
+    });
+    return '<svg viewBox="0 0 ' + width + ' ' + height + '" preserveAspectRatio="none" role="img">' +
+      paths + '</svg>' +
+      '<div class="axis"><span>' + dateList[0] + '</span><span>peak ' + fmt(yMax, 0) +
+      ' MWh</span><span>' + dateList[n - 1] + '</span></div>';
+  }
+
+  /* ---- horizontal bars ---- */
+  function hbars(rows) {
     if (!rows.length) return '<div class="nodata">no data in range</div>';
     var maxV = Math.max.apply(null, rows.map(function (r) { return r.value; })) || 0;
     return rows.map(function (r) {
       var pct = maxV ? Math.max(1.5, (r.value / maxV) * 100) : 0;
-      var cls = "hbar-fill" + (showType && r.type === "solar" ? " solar" : "");
-      return '<div class="hbar-row"><div class="hbar-label">' + r.label + '</div>' +
-        '<div class="hbar-track"><div class="' + cls + '" style="width: ' + pct + '%"></div></div>' +
+      return '<div class="hbar-row"><div class="hbar-label" title="' + r.label + '">' + r.label + '</div>' +
+        '<div class="hbar-track"><div class="hbar-fill" style="width: ' + pct + '%; background: ' + r.color + '"></div></div>' +
         '<div class="hbar-value">' + fmt(r.value, 2) + '</div></div>';
     }).join("");
   }
@@ -108,28 +188,64 @@
     var g = {};
     fd.forEach(function (r) { (g[r.asset_id] = g[r.asset_id] || []).push(num(r.daily_capacity_factor)); });
     return Object.keys(g).sort().map(function (id) {
-      var a = g[id]; return { label: id, value: a.reduce(function (s, v) { return s + v; }, 0) / a.length, type: typeById[id] || "" };
+      var a = g[id];
+      return { label: nameById[id] || id, value: a.reduce(function (s, v) { return s + v; }, 0) / a.length,
+        color: colorFor(typeOf(id)) };
     });
   }
 
   function typeSplit(fd) {
     var t = {};
-    fd.forEach(function (r) { var k = typeById[r.asset_id] || "unknown"; t[k] = (t[k] || 0) + num(r.total_net_generation_mwh); });
-    return Object.keys(t).sort().map(function (k) { return { label: k, value: t[k] }; });
+    fd.forEach(function (r) {
+      var k = r.asset_type || typeOf(r.asset_id);
+      t[k] = (t[k] || 0) + num(r.total_net_generation_mwh);
+    });
+    return Object.keys(t).sort().map(function (k) { return { label: k, value: t[k], color: colorFor(k) }; });
+  }
+
+  /* ---- fleet roster ---- */
+  function roster(fd, ids) {
+    var g = {};
+    fd.forEach(function (r) {
+      (g[r.asset_id] = g[r.asset_id] || { cf: [], gen: 0 });
+      g[r.asset_id].cf.push(num(r.daily_capacity_factor));
+      g[r.asset_id].gen += num(r.total_net_generation_mwh);
+    });
+    var ordered = assets.filter(function (a) { return ids.has(a.asset_id); });
+    if (!ordered.length) return '<div class="nodata">no assets selected</div>';
+    var rows = ordered.map(function (a) {
+      var s = g[a.asset_id] || { cf: [0], gen: 0 };
+      var cf = s.cf.reduce(function (x, y) { return x + y; }, 0) / s.cf.length;
+      return '<tr><td>' + (nameById[a.asset_id] || a.asset_id) + '</td>' +
+        '<td><span class="type-chip" style="--dot: ' + colorFor(a.asset_type) + '">' + a.asset_type + '</span></td>' +
+        '<td>' + fmt(+a.capacity_mw, 0) + ' MW</td>' +
+        '<td>' + (a.region || "—") + '</td>' +
+        '<td>' + (cf * 100).toFixed(1) + '%</td>' +
+        '<td>' + fmt(s.gen, 0) + '</td></tr>';
+    }).join("");
+    return '<div style="overflow-x:auto"><table class="roster"><thead><tr>' +
+      '<th>asset</th><th>technology</th><th>capacity</th><th>region</th>' +
+      '<th>capacity factor</th><th>net gen (MWh)</th></tr></thead><tbody>' +
+      rows + '</tbody></table></div>';
   }
 
   function apply() {
     var ids = allowedIds();
     var fd = filt(daily, ids), fw = filt(weather, ids);
-    setKpis(fd, fw);
-    setHtml("chart-generation", lineSvg(byDateSum(fd, "total_net_generation_mwh"), 720, 200, 8));
-    setHtml("chart-capacity_factor", lineSvg(byDateMean(fd, "daily_capacity_factor"), 720, 160, 8));
-    setHtml("chart-performance", lineSvg(byDateMean(fw, "performance_score"), 720, 160, 8));
-    setHtml("chart-asset_bars", hbars(assetBars(fd), true));
-    setHtml("chart-type_split", hbars(typeSplit(fd), false));
+    setKpis(fd);
+    setHtml("chart-generation", lineSvg(byDateSum(fd, "total_net_generation_mwh"), 720, 200, PRIMARY));
+    setHtml("chart-mix", stackedMix(fd, 720, 220));
+    setHtml("chart-asset_bars", hbars(assetBars(fd)));
+    setHtml("chart-type_split", hbars(typeSplit(fd)));
+    setHtml("chart-battery_soc", lineSvg(byDateMean(fd, "avg_soc_pct", { battery: 1 }, true), 720, 160, TYPE_COLORS.battery));
+    setHtml("chart-emissions", lineSvg(byDateSum(fd, "total_co2_tonnes", { gas: 1 }), 720, 160, TYPE_COLORS.gas));
+    setHtml("chart-capacity_factor", lineSvg(byDateMean(fd, "daily_capacity_factor", CF_TYPES), 720, 160, PRIMARY));
+    setHtml("chart-performance", lineSvg(byDateMean(fw, "performance_score"), 720, 160, GOLD));
+    setHtml("fleet-roster", roster(fd, ids));
   }
 
   [fType, fAsset, fStart, fEnd].forEach(function (c) {
     if (c) c.addEventListener("change", apply);
   });
+  apply();
 })();

--- a/src/weather_analytics/cockpit/templates/index.html.j2
+++ b/src/weather_analytics/cockpit/templates/index.html.j2
@@ -2,17 +2,17 @@
 {%- macro _line_svg(s) -%}
 {%- if s -%}
 <svg viewBox="0 0 {{ s.width }} {{ s.height }}" preserveAspectRatio="none" role="img">
-  <path d="{{ s.area_path }}" fill="rgba(90,169,230,0.20)" />
-  <polyline points="{{ s.polyline }}" fill="none" stroke="var(--accent)" stroke-width="2" />
+  <path d="{{ s.area_path }}" fill="{{ s.color }}" fill-opacity="0.12" />
+  <polyline points="{{ s.polyline }}" fill="none" stroke="{{ s.color }}" stroke-width="2" />
 </svg>
-<div class="axis"><span>{{ s.x0_label }}</span><span>max {{ '%.2f'|format(s.y_max) }}</span><span>{{ s.x1_label }}</span></div>
+<div class="axis"><span>{{ s.x0_label }}</span><span>peak {{ '%.2f'|format(s.y_max) }}</span><span>{{ s.x1_label }}</span></div>
 {%- else -%}<div class="nodata">no data in range</div>{%- endif -%}
 {%- endmacro -%}
-{%- macro _hbars_html(rows, show_type) -%}
+{%- macro _hbars_html(rows) -%}
 {%- if rows -%}
 {%- for r in rows -%}
-<div class="hbar-row"><div class="hbar-label">{{ r.label }}</div>
-<div class="hbar-track"><div class="hbar-fill{% if show_type and r.asset_type == 'solar' %} solar{% endif %}" style="width: {{ r.pct }}%"></div></div>
+<div class="hbar-row"><div class="hbar-label" title="{{ r.name or r.label }}">{{ r.name or r.label }}</div>
+<div class="hbar-track"><div class="hbar-fill" style="width: {{ r.pct }}%; background: {{ r.color or 'var(--data-green)' }}"></div></div>
 <div class="hbar-value">{{ r.disp }}</div></div>
 {%- endfor -%}
 {%- else -%}<div class="nodata">no data in range</div>{%- endif -%}
@@ -23,62 +23,124 @@
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <title>Weather-Adjusted Generation Analytics</title>
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600&display=swap" rel="stylesheet" />
 <style>
   :root {
-    --bg: #0f1115; --card: #171a21; --ink: #e6e9ef; --muted: #9aa4b2;
-    --accent: #5aa9e6; --accent2: #7ee0c0; --line: #262b34;
+    --white: #fff; --gray-50: #f9f9f9; --gray-100: #f0f0f0; --gray-200: #e0e0e0;
+    --gray-500: #666; --gray-600: #555; --gray-800: #353535;
+    --accent-blue: rgb(235, 241, 248); --accent-soft: rgba(235, 241, 248, 0.5);
+    --data-green: #2f6f5f; --data-gold: #b0872f;
+    --wind: #2f6f5f; --solar: #d4a12e; --battery: #3f7cac; --gas: #9c5b3b;
+    --bg: var(--gray-50); --card: var(--white);
+    --ink: var(--gray-800); --muted: var(--gray-500); --line: var(--gray-200);
+    --radius-card: 10px; --radius-sm: 8px; --radius-pill: 2rem;
+    --shadow-card: 0 4px 6px rgba(0, 0, 0, 0.08);
+    --shadow-hover: 0 8px 12px rgba(0, 0, 0, 0.14);
+    --transition: 300ms ease;
+    --font: 'Poppins', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
   }
   * { box-sizing: border-box; }
   body { margin: 0; background: var(--bg); color: var(--ink);
-    font: 14px/1.5 -apple-system, Segoe UI, Roboto, sans-serif; }
-  header { padding: 24px 20px 8px; }
-  h1 { margin: 0; font-size: 20px; }
-  .sub { color: var(--muted); font-size: 12px; margin-top: 4px; }
-  .wrap { padding: 12px 20px 48px; max-width: 1000px; margin: 0 auto; }
-  .controls { display: flex; flex-wrap: wrap; gap: 10px; margin: 12px 0; }
-  .controls label { color: var(--muted); font-size: 12px; display: flex;
-    flex-direction: column; gap: 4px; }
+    font-family: var(--font); font-size: 14px; line-height: 1.5;
+    -webkit-font-smoothing: antialiased; }
+  a { color: var(--data-green); }
+  header { max-width: 1160px; margin: 0 auto; padding: 40px 24px 8px; }
+  h1 { margin: 0; font-size: 1.75rem; font-weight: 600; letter-spacing: -0.01em; }
+  .sub { color: var(--muted); font-size: 0.9rem; margin-top: 8px;
+    display: flex; flex-wrap: wrap; gap: 6px 14px; align-items: center; }
+  .badge { display: inline-flex; align-items: center; gap: 6px;
+    background: var(--accent-soft); color: var(--gray-800); font-size: 0.78rem;
+    font-weight: 500; padding: 3px 12px; border-radius: var(--radius-pill); }
+  .badge.live::before { content: ""; width: 7px; height: 7px; border-radius: 50%;
+    background: var(--data-green); }
+  .badge.sim::before { content: ""; width: 7px; height: 7px; border-radius: 50%;
+    background: var(--data-gold); }
+  .wrap { max-width: 1160px; margin: 0 auto; padding: 12px 24px 64px; }
+  .controls { display: flex; flex-wrap: wrap; gap: 14px; margin: 20px 0 8px; }
+  .controls label { color: var(--muted); font-size: 0.78rem; font-weight: 500;
+    text-transform: uppercase; letter-spacing: 0.04em;
+    display: flex; flex-direction: column; gap: 5px; }
   .controls select, .controls input {
-    background: var(--card); color: var(--ink); border: 1px solid var(--line);
-    border-radius: 6px; padding: 6px 8px; }
-  .kpis { display: grid; grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
-    gap: 12px; margin: 12px 0; }
-  .kpi { background: var(--card); border: 1px solid var(--line); border-radius: 10px;
-    padding: 14px 16px; }
-  .kpi .label { color: var(--muted); font-size: 11px; text-transform: uppercase;
-    letter-spacing: .04em; }
-  .kpi .value { font-size: 26px; font-weight: 600; margin-top: 6px; }
-  .card { background: var(--card); border: 1px solid var(--line); border-radius: 10px;
-    padding: 16px; margin: 12px 0; }
-  .card h2 { margin: 0 0 10px; font-size: 13px; color: var(--muted);
-    text-transform: uppercase; letter-spacing: .04em; }
+    background: var(--white); color: var(--ink); border: 1px solid var(--line);
+    border-radius: var(--radius-sm); padding: 8px 10px; font-family: var(--font);
+    font-size: 0.9rem; font-weight: 400; text-transform: none; letter-spacing: 0; }
+  .controls select:focus, .controls input:focus {
+    outline: none; border-color: var(--data-green); }
+  .legend { display: flex; flex-wrap: wrap; gap: 8px 16px; margin: 8px 0 4px; }
+  .legend-item { display: inline-flex; align-items: center; gap: 6px;
+    font-size: 0.82rem; color: var(--gray-600); }
+  .legend-dot { width: 11px; height: 11px; border-radius: 3px; }
+  .kpis { display: grid; gap: 14px; margin: 16px 0;
+    grid-template-columns: repeat(auto-fit, minmax(165px, 1fr)); }
+  .kpi { background: var(--card); border: 1px solid var(--line);
+    border-radius: var(--radius-card); padding: 16px 18px;
+    box-shadow: var(--shadow-card); transition: transform var(--transition),
+      box-shadow var(--transition); }
+  .kpi:hover { transform: translateY(-3px); box-shadow: var(--shadow-hover); }
+  .kpi .label { color: var(--muted); font-size: 0.72rem; font-weight: 500;
+    text-transform: uppercase; letter-spacing: 0.05em; }
+  .kpi .value { font-size: 1.9rem; font-weight: 600; margin-top: 8px;
+    font-variant-numeric: tabular-nums; letter-spacing: -0.02em; }
+  .kpi .unit { color: var(--muted); font-size: 0.72rem; margin-top: 2px; }
+  .grid2 { display: grid; gap: 16px; grid-template-columns: 1fr 1fr; }
+  @media (max-width: 720px) { .grid2 { grid-template-columns: 1fr; } }
+  .card { background: var(--card); border: 1px solid var(--line);
+    border-radius: var(--radius-card); padding: 20px; margin: 16px 0;
+    box-shadow: var(--shadow-card); }
+  .card h2 { margin: 0 0 14px; font-size: 0.78rem; color: var(--muted);
+    font-weight: 600; text-transform: uppercase; letter-spacing: 0.06em; }
   svg { width: 100%; height: auto; display: block; }
-  .hbar-row { display: grid; grid-template-columns: 80px 1fr 90px; align-items: center;
-    gap: 8px; margin: 6px 0; }
-  .hbar-track { background: var(--line); border-radius: 5px; height: 12px; overflow: hidden; }
-  .hbar-fill { background: var(--accent); height: 100%; }
-  .hbar-fill.solar { background: var(--accent2); }
-  .hbar-value { text-align: right; color: var(--muted); font-variant-numeric: tabular-nums; }
-  .nodata { color: var(--muted); font-style: italic; }
+  .hbar-row { display: grid; grid-template-columns: 130px 1fr 92px;
+    align-items: center; gap: 10px; margin: 8px 0; }
+  .hbar-label { font-size: 0.85rem; overflow: hidden; text-overflow: ellipsis;
+    white-space: nowrap; }
+  .hbar-track { background: var(--gray-100); border-radius: 5px; height: 12px;
+    overflow: hidden; }
+  .hbar-fill { height: 100%; border-radius: 5px; transition: width var(--transition); }
+  .hbar-value { text-align: right; color: var(--gray-600);
+    font-variant-numeric: tabular-nums; font-size: 0.85rem; }
+  .nodata { color: var(--muted); font-style: italic; padding: 8px 0; }
   .axis { display: flex; justify-content: space-between; color: var(--muted);
-    font-size: 11px; margin-top: 4px; }
+    font-size: 0.72rem; margin-top: 6px; }
+  table.roster { width: 100%; border-collapse: collapse; font-size: 0.85rem; }
+  table.roster th { text-align: left; color: var(--muted); font-weight: 500;
+    font-size: 0.72rem; text-transform: uppercase; letter-spacing: 0.04em;
+    padding: 6px 10px; border-bottom: 1px solid var(--line); }
+  table.roster td { padding: 8px 10px; border-bottom: 1px solid var(--gray-100);
+    font-variant-numeric: tabular-nums; }
+  .type-chip { display: inline-flex; align-items: center; gap: 6px;
+    font-size: 0.78rem; text-transform: capitalize; }
+  .type-chip::before { content: ""; width: 9px; height: 9px; border-radius: 3px;
+    background: var(--dot, var(--muted)); }
+  footer { max-width: 1160px; margin: 0 auto; padding: 8px 24px 48px;
+    color: var(--muted); font-size: 0.78rem; }
 </style>
 </head>
 <body>
 <header>
   <h1>Weather-Adjusted Generation Analytics</h1>
   <div class="sub">
-    {{ manifest.date_range_start }} → {{ manifest.date_range_end }} ·
-    {{ manifest.asset_count }} assets · generated {{ manifest.generated_at }}
+    <span>{{ manifest.date_range_start }} &rarr; {{ manifest.date_range_end }}</span>
+    <span>&middot; {{ manifest.asset_count }} assets</span>
+    {% if manifest.weather_source == 'open-meteo' -%}
+    <span class="badge live">live Open-Meteo weather</span>
+    {%- elif manifest.weather_source == 'synthetic' -%}
+    <span class="badge sim">simulated weather</span>
+    {%- endif %}
+    <span>&middot; generated {{ manifest.generated_at }}</span>
   </div>
 </header>
 <div class="wrap">
   <div class="controls">
-    <label>asset type
+    <label>technology
       <select id="f-type">
         <option value="">all</option>
         <option value="wind">wind</option>
         <option value="solar">solar</option>
+        <option value="battery">battery</option>
+        <option value="gas">gas</option>
       </select>
     </label>
     <label>asset
@@ -91,28 +153,57 @@
     <label>to<input type="date" id="f-end" value="{{ manifest.date_range_end }}" /></label>
   </div>
 
+  <div class="legend">
+    <span class="legend-item"><span class="legend-dot" style="background: var(--wind)"></span>wind</span>
+    <span class="legend-item"><span class="legend-dot" style="background: var(--solar)"></span>solar</span>
+    <span class="legend-item"><span class="legend-dot" style="background: var(--battery)"></span>battery</span>
+    <span class="legend-item"><span class="legend-dot" style="background: var(--gas)"></span>gas</span>
+  </div>
+
   <div class="kpis" id="kpis">
     {% for k in kpis %}
     <div class="kpi"><div class="label">{{ k.label }}</div>
-      <div class="value" data-kpi="{{ k.key }}">{{ k.value }}</div></div>
+      <div class="value" data-kpi="{{ k.key }}">{{ k.value }}</div>
+      {% if k.unit %}<div class="unit">{{ k.unit }}</div>{% endif %}</div>
     {% endfor %}
   </div>
 
-  <div class="card"><h2>net generation (MWh)</h2>
+  <div class="card"><h2>fleet net generation (MWh / day)</h2>
     <div id="chart-generation">{{ _line_svg(generation) }}</div></div>
 
-  <div class="card"><h2>capacity factor</h2>
-    <div id="chart-capacity_factor">{{ _line_svg(capacity_factor) }}</div></div>
+  <div class="card"><h2>generation mix by technology</h2>
+    <div id="chart-mix"><div class="nodata">loading&hellip;</div></div></div>
 
-  <div class="card"><h2>weather-adjusted performance score</h2>
-    <div id="chart-performance">{{ _line_svg(performance) }}</div></div>
+  <div class="grid2">
+    <div class="card"><h2>capacity factor by asset</h2>
+      <div id="chart-asset_bars">{{ _hbars_html(asset_bars) }}</div></div>
+    <div class="card"><h2>net generation by technology (MWh)</h2>
+      <div id="chart-type_split">{{ _hbars_html(type_split) }}</div></div>
+  </div>
 
-  <div class="card"><h2>capacity factor by asset</h2>
-    <div id="chart-asset_bars">{{ _hbars_html(asset_bars, true) }}</div></div>
+  <div class="grid2">
+    <div class="card"><h2>battery state of charge (%)</h2>
+      <div id="chart-battery_soc">{{ _line_svg(battery_soc) }}</div></div>
+    <div class="card"><h2>gas CO&#8322; emissions (tonnes / day)</h2>
+      <div id="chart-emissions">{{ _line_svg(emissions) }}</div></div>
+  </div>
 
-  <div class="card"><h2>generation by type</h2>
-    <div id="chart-type_split">{{ _hbars_html(type_split, false) }}</div></div>
+  <div class="card"><h2>fleet capacity factor &amp; weather-adjusted score</h2>
+    <div class="grid2">
+      <div><div class="axis" style="margin:0 0 6px"><span>capacity factor</span></div>
+        <div id="chart-capacity_factor">{{ _line_svg(capacity_factor) }}</div></div>
+      <div><div class="axis" style="margin:0 0 6px"><span>weather-adjusted performance score</span></div>
+        <div id="chart-performance">{{ _line_svg(performance) }}</div></div>
+    </div></div>
+
+  <div class="card"><h2>fleet roster</h2>
+    <div id="fleet-roster"><div class="nodata">loading&hellip;</div></div></div>
 </div>
+
+<footer>
+  Built from a local WAGA fleet simulation &middot; wind / solar / battery / gas
+  &middot; data schema v{{ manifest.schema_version }}
+</footer>
 
 <script type="application/json" id="cockpit-data">{{ data_island | safe }}</script>
 <script>{{ app_js | safe }}</script>

--- a/src/weather_analytics/mock_data/fleet.py
+++ b/src/weather_analytics/mock_data/fleet.py
@@ -1,0 +1,313 @@
+"""Realistic mixed-technology fleet registry.
+
+Defines the assets the local simulation drives: onshore wind, utility solar PV,
+grid-scale battery storage, and natural-gas generation (combined-cycle and
+peaker). Each asset carries a real US latitude/longitude so the simulation can
+pull genuine hourly weather from Open-Meteo and produce genuinely variable,
+site-specific output.
+
+This is the source of truth for the *local dashboard* fleet. The Snowflake
+ingestion path keeps its own wind/solar-only ``ASSET_CONFIGS`` (see
+``generate_generation.ASSET_CONFIGS``); the two are deliberately independent so
+adding thermal/storage assets here never touches the contracted dbt marts.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+# Asset technology categories.
+WIND = "wind"
+SOLAR = "solar"
+BATTERY = "battery"
+GAS = "gas"
+
+ASSET_TYPES: tuple[str, ...] = (WIND, SOLAR, BATTERY, GAS)
+
+
+@dataclass(frozen=True)
+class WindParams:
+    """Turbine power-curve and loss parameters.
+
+    Attributes
+    ----------
+    cut_in_mps, rated_mps, cut_out_mps : float
+        Characteristic wind speeds (m/s) of the piecewise power curve.
+    wake_loss : float
+        Fractional array wake loss (0.10 == 10% lost).
+    availability : float
+        Mechanical availability factor (0.95 == 95% uptime).
+    turbulence_intensity : float
+        Stationary std of the multiplicative AR(1) wind-speed noise.
+    """
+
+    cut_in_mps: float = 3.0
+    rated_mps: float = 12.0
+    cut_out_mps: float = 25.0
+    wake_loss: float = 0.10
+    availability: float = 0.95
+    turbulence_intensity: float = 0.12
+
+
+@dataclass(frozen=True)
+class SolarParams:
+    """PV system parameters (NOCT cell-temp + inverter-clipping model).
+
+    Attributes
+    ----------
+    noct_c : float
+        Nominal operating cell temperature (°C).
+    temp_coeff_per_c : float
+        Power temperature coefficient (per °C, negative), referenced to 25 °C.
+    dc_ac_ratio : float
+        Inverter load ratio; AC rating = DC nameplate / dc_ac_ratio.
+    system_derate : float
+        Combined DC-side system losses factor (0.86 == 14% loss, PVWatts v8).
+    """
+
+    noct_c: float = 45.0
+    temp_coeff_per_c: float = -0.004
+    dc_ac_ratio: float = 1.2
+    system_derate: float = 0.86
+
+
+@dataclass(frozen=True)
+class BatteryParams:
+    """Grid Li-ion storage parameters.
+
+    Attributes
+    ----------
+    duration_h : float
+        Storage duration at rated power (energy = power * duration).
+    round_trip_efficiency : float
+        AC-to-AC round-trip efficiency; split symmetrically across legs.
+    soc_min_frac, soc_max_frac : float
+        Usable state-of-charge window as fractions of energy capacity.
+    aux_load_frac : float
+        Hourly parasitic/auxiliary draw as a fraction of rated power.
+    """
+
+    duration_h: float = 4.0
+    round_trip_efficiency: float = 0.88
+    soc_min_frac: float = 0.10
+    soc_max_frac: float = 0.95
+    aux_load_frac: float = 0.003
+
+
+@dataclass(frozen=True)
+class GasParams:
+    """Natural-gas unit parameters (CCGT or simple-cycle peaker).
+
+    Attributes
+    ----------
+    subtype : str
+        ``"ccgt"`` or ``"peaker"`` — sets merit-order position.
+    heat_rate_btu_kwh : float
+        Full-load heat rate (Btu/kWh); lower == more efficient.
+    min_load_frac : float
+        Minimum stable load as a fraction of capacity.
+    ramp_frac_per_hr : float
+        Max change in output per hour as a fraction of capacity.
+    forced_outage_rate : float
+        Equivalent forced-outage rate (EFOR); hourly trip probability.
+    part_load_a, part_load_b : float
+        Part-load heat-rate curve HR(x) = HR_full * (a + b/x); a + b == 1.
+    """
+
+    subtype: str = "ccgt"
+    heat_rate_btu_kwh: float = 6900.0
+    min_load_frac: float = 0.40
+    ramp_frac_per_hr: float = 0.80
+    forced_outage_rate: float = 0.03
+    part_load_a: float = 0.90
+    part_load_b: float = 0.10
+
+
+# Emissions factor for natural gas combustion (tonnes CO2 per MMBtu of fuel).
+# EPA: ~53.06 kg CO2 / MMBtu for natural gas.
+CO2_TONNES_PER_MMBTU: float = 0.05306
+
+
+@dataclass(frozen=True)
+class FleetAsset:
+    """One physical asset in the simulated fleet.
+
+    Attributes
+    ----------
+    asset_id : str
+        Stable identifier (``ASSET_0NN``) matching the export/UI convention.
+    name : str
+        Human-readable site name.
+    asset_type : str
+        One of :data:`ASSET_TYPES`.
+    capacity_mw : float
+        Nameplate power capacity (MW). For solar this is the AC/inverter rating.
+    latitude, longitude : float
+        Site coordinates (WGS84) used for the weather pull.
+    region : str
+        Grid/region label for grouping in the dashboard.
+    wind, solar, battery, gas : params | None
+        Exactly one is populated, matching ``asset_type``.
+    """
+
+    asset_id: str
+    name: str
+    asset_type: str
+    capacity_mw: float
+    latitude: float
+    longitude: float
+    region: str
+    wind: WindParams | None = None
+    solar: SolarParams | None = None
+    battery: BatteryParams | None = None
+    gas: GasParams | None = None
+
+    @property
+    def size_category(self) -> str:
+        """Bucket capacity into Small/Medium/Large (matches dbt staging)."""
+        if self.capacity_mw >= 75:
+            return "Large"
+        if self.capacity_mw >= 50:
+            return "Medium"
+        return "Small"
+
+    @property
+    def display_name(self) -> str:
+        """Label shown in the dashboard asset picker."""
+        return f"{self.name} ({self.capacity_mw:.0f} MW {self.asset_type})"
+
+
+def _wind(
+    asset_id: str,
+    name: str,
+    mw: float,
+    lat: float,
+    lon: float,
+    region: str,
+    **kw: float,
+) -> FleetAsset:
+    params = WindParams(**kw)
+    return FleetAsset(asset_id, name, WIND, mw, lat, lon, region, wind=params)
+
+
+def _solar(
+    asset_id: str,
+    name: str,
+    mw: float,
+    lat: float,
+    lon: float,
+    region: str,
+    **kw: float,
+) -> FleetAsset:
+    params = SolarParams(**kw)
+    return FleetAsset(asset_id, name, SOLAR, mw, lat, lon, region, solar=params)
+
+
+def _battery(
+    asset_id: str,
+    name: str,
+    mw: float,
+    lat: float,
+    lon: float,
+    region: str,
+    **kw: float,
+) -> FleetAsset:
+    params = BatteryParams(**kw)
+    return FleetAsset(asset_id, name, BATTERY, mw, lat, lon, region, battery=params)
+
+
+def _gas(
+    asset_id: str,
+    name: str,
+    mw: float,
+    lat: float,
+    lon: float,
+    region: str,
+    **kw: object,
+) -> FleetAsset:
+    params = GasParams(**kw)  # type: ignore[arg-type]
+    return FleetAsset(asset_id, name, GAS, mw, lat, lon, region, gas=params)
+
+
+# ---------------------------------------------------------------------------
+# The fleet: 12 assets across four technologies at real US sites.
+# Coordinates chosen for representative resource quality (windy plains, sunny
+# Southwest) so the Open-Meteo pull yields believable, site-specific profiles.
+# ---------------------------------------------------------------------------
+FLEET: tuple[FleetAsset, ...] = (
+    # --- Onshore wind: high-wind interior sites ---
+    _wind("ASSET_001", "Roscoe Ridge", 150.0, 32.45, -100.54, "ERCOT"),
+    _wind("ASSET_002", "Buffalo Ridge", 100.0, 44.30, -96.20, "MISO"),
+    _wind(
+        "ASSET_003",
+        "Cheyenne Mesa",
+        120.0,
+        41.14,
+        -104.82,
+        "WECC",
+        turbulence_intensity=0.14,
+    ),
+    _wind("ASSET_004", "Storm Lake", 80.0, 42.64, -95.20, "MISO"),
+    # --- Utility solar PV: Southwest high-irradiance sites ---
+    _solar("ASSET_005", "Mojave Flats", 90.0, 35.01, -117.30, "CAISO"),
+    _solar("ASSET_006", "Gila Bend", 75.0, 32.95, -112.72, "WECC"),
+    _solar("ASSET_007", "Pecos Plains", 60.0, 31.42, -103.49, "ERCOT"),
+    _solar("ASSET_008", "Boulder Basin", 45.0, 35.98, -114.84, "WECC", dc_ac_ratio=1.3),
+    # --- Grid battery storage ---
+    _battery("ASSET_009", "Moss Landing Cells", 100.0, 36.80, -121.78, "CAISO"),
+    _battery(
+        "ASSET_010", "Angleton Store", 60.0, 29.17, -95.43, "ERCOT", duration_h=2.0
+    ),
+    # --- Natural gas ---
+    _gas(
+        "ASSET_011",
+        "Deer Park CCGT",
+        200.0,
+        29.70,
+        -95.12,
+        "ERCOT",
+        subtype="ccgt",
+        heat_rate_btu_kwh=6900.0,
+        min_load_frac=0.40,
+        ramp_frac_per_hr=0.80,
+        forced_outage_rate=0.03,
+    ),
+    _gas(
+        "ASSET_012",
+        "Sunrise Peaker",
+        90.0,
+        35.35,
+        -119.02,
+        "CAISO",
+        subtype="peaker",
+        heat_rate_btu_kwh=10500.0,
+        min_load_frac=0.30,
+        ramp_frac_per_hr=3.0,
+        forced_outage_rate=0.04,
+    ),
+)
+
+FLEET_BY_ID: dict[str, FleetAsset] = {a.asset_id: a for a in FLEET}
+
+
+def assets_of_type(asset_type: str) -> list[FleetAsset]:
+    """Return all fleet assets of a given technology."""
+    return [a for a in FLEET if a.asset_type == asset_type]
+
+
+__all__ = [
+    "ASSET_TYPES",
+    "BATTERY",
+    "CO2_TONNES_PER_MMBTU",
+    "FLEET",
+    "FLEET_BY_ID",
+    "GAS",
+    "SOLAR",
+    "WIND",
+    "BatteryParams",
+    "FleetAsset",
+    "GasParams",
+    "SolarParams",
+    "WindParams",
+    "assets_of_type",
+]

--- a/src/weather_analytics/mock_data/local_export.py
+++ b/src/weather_analytics/mock_data/local_export.py
@@ -1,0 +1,409 @@
+"""Build the dashboard JSON exports locally, without Snowflake.
+
+This mirrors the aggregation math of the dbt marts + the Dagster
+``waga_dashboard_export_build`` asset, but runs entirely on in-memory Polars
+frames from :func:`weather_analytics.mock_data.simulate.simulate_fleet`. It is
+what lets the multi-technology fleet (wind, solar, battery, gas) reach the
+static dashboard on a laptop or in CI with no warehouse credentials.
+
+Weather-adjusted performance (expected-vs-actual regression) is computed for
+wind and solar exactly as the mart does. Battery and gas are not weather-driven,
+so they get technology-appropriate scores (storage round-trip efficiency; gas
+part-load efficiency) and carry extra columns (SOC, throughput, fuel, CO2).
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import polars as pl
+
+from weather_analytics.mock_data.fleet import (
+    BATTERY,
+    FLEET,
+    GAS,
+    SOLAR,
+    WIND,
+    FleetAsset,
+)
+from weather_analytics.mock_data.simulate import SimulationResult, simulate_fleet
+
+SCHEMA_VERSION = "2.0"
+
+_RATING_HIGH = 0.6
+_RATING_MEDIUM = 0.3
+
+
+@dataclass(frozen=True)
+class ExportBundle:
+    """The four JSON payloads (as Python objects) plus the manifest."""
+
+    manifest: dict[str, Any]
+    assets: list[dict[str, Any]]
+    daily: list[dict[str, Any]]
+    weather: list[dict[str, Any]]
+
+
+def _linfit(x: np.ndarray, y: np.ndarray) -> tuple[float, float, float]:
+    """Least-squares slope, intercept, and R^2 of y on x."""
+    if x.size < 2 or np.allclose(x, x[0]):
+        return 0.0, float(np.mean(y)) if y.size else 0.0, 0.0
+    slope, intercept = np.polyfit(x, y, 1)
+    pred = slope * x + intercept
+    ss_res = float(np.sum((y - pred) ** 2))
+    ss_tot = float(np.sum((y - np.mean(y)) ** 2))
+    r2 = 0.0 if ss_tot == 0 else max(0.0, 1.0 - ss_res / ss_tot)
+    return float(slope), float(intercept), r2
+
+
+def _hourly_rating(cf: np.ndarray) -> np.ndarray:
+    """Per-hour performance bucket from capacity factor (mirrors stg_generation)."""
+    return np.select(
+        [cf > 0.9, cf > 0.6, cf > 0.3, cf > 0.05],
+        ["Excellent", "Good", "Fair", "Poor"],
+        default="Very Poor",
+    )
+
+
+def _daily_frame(gen: pl.DataFrame, weather: pl.DataFrame) -> pl.DataFrame:
+    """Roll hourly generation + weather up to per-asset-per-day rows."""
+    gen = gen.with_columns(
+        pl.col("timestamp").dt.date().alias("date"),
+        (pl.col("net_generation_mwh") / pl.col("asset_capacity_mw")).alias(
+            "_hourly_cf"
+        ),
+    )
+    ratings = _hourly_rating(gen["_hourly_cf"].to_numpy())
+    gen = gen.with_columns(pl.Series("_rating", ratings))
+
+    daily_gen = gen.group_by(["asset_id", "date"]).agg(
+        pl.col("asset_type").first(),
+        pl.col("asset_capacity_mw").max(),
+        pl.col("gross_generation_mwh").sum().alias("total_gross_generation_mwh"),
+        pl.col("net_generation_mwh").sum().alias("total_net_generation_mwh"),
+        pl.col("curtailment_mwh").sum().alias("total_curtailment_mwh"),
+        pl.col("availability_pct").mean().alias("avg_availability_pct"),
+        pl.len().alias("_hours"),
+        (pl.col("_rating") == "Excellent").sum().alias("excellent_hours"),
+        (pl.col("_rating") == "Good").sum().alias("good_hours"),
+        (pl.col("_rating") == "Fair").sum().alias("fair_hours"),
+        (pl.col("_rating") == "Poor").sum().alias("poor_hours"),
+        pl.col("soc_pct").mean().alias("avg_soc_pct"),
+        pl.col("charge_mwh").sum().alias("total_charge_mwh"),
+        pl.col("discharge_mwh").sum().alias("total_discharge_mwh"),
+        pl.col("fuel_mmbtu").sum().alias("total_fuel_mmbtu"),
+        pl.col("heat_rate_btu_kwh").mean().alias("avg_heat_rate_btu_kwh"),
+        pl.col("co2_tonnes").sum().alias("total_co2_tonnes"),
+    )
+
+    daily_weather = (
+        weather.with_columns(pl.col("timestamp").dt.date().alias("date"))
+        .group_by(["asset_id", "date"])
+        .agg(
+            pl.col("wind_speed_mps").mean().alias("avg_wind_speed_mps"),
+            pl.col("ghi").mean().alias("avg_ghi"),
+            pl.col("temperature_c").mean().alias("avg_temperature_c"),
+        )
+    )
+
+    daily = daily_gen.join(daily_weather, on=["asset_id", "date"], how="left")
+    daily = daily.with_columns(
+        (
+            pl.col("total_net_generation_mwh")
+            / (pl.col("asset_capacity_mw") * pl.col("_hours"))
+        ).alias("daily_capacity_factor"),
+        pl.lit(100.0).alias("data_completeness_pct"),
+    )
+    daily = daily.with_columns(
+        pl.when(pl.col("daily_capacity_factor") >= _RATING_HIGH)
+        .then(pl.lit("High"))
+        .when(pl.col("daily_capacity_factor") >= _RATING_MEDIUM)
+        .then(pl.lit("Medium"))
+        .otherwise(pl.lit("Low"))
+        .alias("daily_performance_rating")
+    )
+    return daily.sort(["asset_id", "date"])
+
+
+def _weather_performance(
+    gen: pl.DataFrame,
+    weather: pl.DataFrame,
+    daily: pl.DataFrame,
+    fleet_by_id: dict[str, FleetAsset],
+) -> pl.DataFrame:
+    """Per-asset-per-day performance scores (weather-adjusted for wind/solar)."""
+    joined = gen.join(
+        weather.select(["timestamp", "asset_id", "wind_speed_mps", "ghi"]),
+        on=["timestamp", "asset_id"],
+        how="left",
+    ).with_columns(pl.col("timestamp").dt.date().alias("date"))
+
+    frames: list[pl.DataFrame] = []
+    for asset_id, asset in fleet_by_id.items():
+        a = joined.filter(pl.col("asset_id") == asset_id).sort("timestamp")
+        if a.height == 0:
+            continue
+        net = a["net_generation_mwh"].to_numpy()
+        dates = a["date"]
+
+        if asset.asset_type in (WIND, SOLAR):
+            driver = (
+                (a["wind_speed_mps"] if asset.asset_type == WIND else a["ghi"])
+                .fill_null(0.0)
+                .to_numpy()
+            )
+            slope, intercept, r2 = _linfit(driver, net)
+            expected = np.clip(slope * driver + intercept, 0.0, None)
+            # Only score "operating" hours: at night / dead-calm the expected
+            # output is ~0, so the actual/expected ratio is undefined noise that
+            # would otherwise drag the daily score toward zero.
+            operating = expected > 0.02 * asset.capacity_mw
+            ratio = np.divide(
+                net * 100.0,
+                expected,
+                out=np.full(net.shape, np.nan),
+                where=operating,
+            )
+            wind_r2 = r2 if asset.asset_type == WIND else None
+            solar_r2 = r2 if asset.asset_type == SOLAR else None
+        else:
+            # Non-weather-driven: score on operational efficiency instead.
+            expected = net.copy()
+            ratio = _operational_ratio(asset, a)
+            wind_r2 = None
+            solar_r2 = None
+
+        per_hour = pl.DataFrame(
+            {
+                "date": dates,
+                "_expected": expected,
+                "_actual": net,
+                "_ratio": ratio,
+            }
+        )
+        agg = per_hour.group_by("date").agg(
+            pl.col("_expected").mean().alias("avg_expected_generation_mwh"),
+            pl.col("_actual").mean().alias("avg_actual_generation_mwh"),
+            # drop_nans so non-operating hours (night / calm) don't poison the
+            # daily mean via NaN propagation.
+            pl.col("_ratio").drop_nans().mean().alias("avg_performance_ratio_pct"),
+        )
+        agg = agg.with_columns(
+            pl.lit(asset_id).alias("asset_id"),
+            pl.lit(asset.asset_type).alias("inferred_asset_type"),
+            pl.lit(wind_r2, dtype=pl.Float64).alias("wind_r_squared"),
+            pl.lit(solar_r2, dtype=pl.Float64).alias("solar_r_squared"),
+            pl.col("avg_performance_ratio_pct")
+            .clip(0.0, 100.0)
+            .alias("performance_score"),
+        )
+        agg = agg.with_columns(
+            pl.when(pl.col("performance_score") >= 95)
+            .then(pl.lit("Excellent"))
+            .when(pl.col("performance_score") >= 85)
+            .then(pl.lit("Good"))
+            .when(pl.col("performance_score") >= 70)
+            .then(pl.lit("Fair"))
+            .otherwise(pl.lit("Poor"))
+            .alias("performance_category")
+        )
+        frames.append(agg)
+
+    weather_perf = pl.concat(frames)
+
+    # Rolling 7d / 30d capacity factor from the daily frame.
+    rolling = (
+        daily.select(["asset_id", "date", "daily_capacity_factor"])
+        .sort(["asset_id", "date"])
+        .with_columns(
+            pl.col("daily_capacity_factor")
+            .rolling_mean(window_size=7, min_samples=1)
+            .over("asset_id")
+            .alias("rolling_7d_avg_cf"),
+            pl.col("daily_capacity_factor")
+            .rolling_mean(window_size=30, min_samples=1)
+            .over("asset_id")
+            .alias("rolling_30d_avg_cf"),
+        )
+        .drop("daily_capacity_factor")
+    )
+
+    return weather_perf.join(rolling, on=["asset_id", "date"], how="left").sort(
+        ["asset_id", "date"]
+    )
+
+
+def _operational_ratio(asset: FleetAsset, hourly: pl.DataFrame) -> np.ndarray:
+    """Technology performance ratio (%) for non-weather assets, per hour.
+
+    Battery: realized round-trip efficiency when discharging. Gas: full-load
+    heat rate as a fraction of the actual (part-load-penalized) heat rate.
+    """
+    n = hourly.height
+    if asset.asset_type == BATTERY:
+        discharge = hourly["discharge_mwh"].fill_null(0.0).to_numpy()
+        assert asset.battery is not None
+        # 100 when delivering at rated round-trip efficiency; scale by activity.
+        active = discharge > 1e-6
+        ratio = np.full(n, np.nan)
+        ratio[active] = asset.battery.round_trip_efficiency * 100.0
+        return ratio
+    if asset.asset_type == GAS:
+        assert asset.gas is not None
+        hr = hourly["heat_rate_btu_kwh"].fill_null(asset.gas.heat_rate_btu_kwh)
+        out = hourly["net_generation_mwh"].to_numpy()
+        hr_np = hr.to_numpy()
+        ratio = np.full(n, np.nan)
+        running = out > 1e-6
+        ratio[running] = np.clip(
+            asset.gas.heat_rate_btu_kwh / hr_np[running] * 100.0, 0.0, 100.0
+        )
+        return ratio
+    return np.full(n, np.nan)
+
+
+def _assets_frame(fleet: tuple[FleetAsset, ...]) -> list[dict[str, Any]]:
+    """Build the asset dimension records for assets.json."""
+    return [
+        {
+            "asset_id": a.asset_id,
+            "capacity_mw": a.capacity_mw,
+            "size_category": a.size_category,
+            "asset_type": a.asset_type,
+            "display_name": a.display_name,
+            "name": a.name,
+            "region": a.region,
+            "latitude": a.latitude,
+            "longitude": a.longitude,
+        }
+        for a in fleet
+    ]
+
+
+def _records(df: pl.DataFrame) -> list[dict[str, Any]]:
+    """Serialize a frame to JSON records, dates as ISO strings, NaN -> None."""
+    casts = [
+        pl.col(c).cast(pl.Utf8) if df[c].dtype.is_temporal() else pl.col(c)
+        for c in df.columns
+    ]
+    return df.select(casts).fill_nan(None).to_dicts()
+
+
+def build_bundle(
+    result: SimulationResult, fleet: tuple[FleetAsset, ...]
+) -> ExportBundle:
+    """Compute all four export payloads from a simulation result."""
+    fleet_by_id = {a.asset_id: a for a in fleet}
+    daily = _daily_frame(result.generation, result.weather)
+    weather_perf = _weather_performance(
+        result.generation, result.weather, daily, fleet_by_id
+    )
+
+    daily_out = daily.select(
+        "asset_id",
+        "date",
+        "total_net_generation_mwh",
+        "daily_capacity_factor",
+        "avg_availability_pct",
+        "total_curtailment_mwh",
+        "daily_performance_rating",
+        "excellent_hours",
+        "good_hours",
+        "fair_hours",
+        "poor_hours",
+        "avg_wind_speed_mps",
+        "avg_ghi",
+        "avg_temperature_c",
+        "data_completeness_pct",
+        "asset_type",
+        "avg_soc_pct",
+        "total_charge_mwh",
+        "total_discharge_mwh",
+        "total_fuel_mmbtu",
+        "avg_heat_rate_btu_kwh",
+        "total_co2_tonnes",
+    )
+    weather_out = weather_perf.select(
+        "asset_id",
+        "date",
+        "performance_score",
+        "performance_category",
+        "avg_expected_generation_mwh",
+        "avg_actual_generation_mwh",
+        "avg_performance_ratio_pct",
+        "wind_r_squared",
+        "solar_r_squared",
+        "inferred_asset_type",
+        "rolling_7d_avg_cf",
+        "rolling_30d_avg_cf",
+    )
+
+    type_counts: dict[str, int] = {}
+    for a in fleet:
+        type_counts[a.asset_type] = type_counts.get(a.asset_type, 0) + 1
+
+    manifest = {
+        "generated_at": datetime.now(tz=UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "weather_source": result.weather_source,
+        "date_range": {
+            "start": str(daily["date"].min()),
+            "end": str(daily["date"].max()),
+        },
+        "asset_count": len(fleet),
+        "asset_type_counts": type_counts,
+        "row_counts": {
+            "daily_performance": daily_out.height,
+            "weather_performance": weather_out.height,
+        },
+        "schema_version": SCHEMA_VERSION,
+    }
+    return ExportBundle(
+        manifest=manifest,
+        assets=_assets_frame(fleet),
+        daily=_records(daily_out),
+        weather=_records(weather_out),
+    )
+
+
+def write_bundle(bundle: ExportBundle, out_dir: Path) -> None:
+    """Write the four JSON export files to ``out_dir``."""
+    out_dir.mkdir(parents=True, exist_ok=True)
+    payloads = {
+        "manifest.json": bundle.manifest,
+        "assets.json": bundle.assets,
+        "daily_performance.json": bundle.daily,
+        "weather_performance.json": bundle.weather,
+    }
+    for name, payload in payloads.items():
+        (out_dir / name).write_text(
+            json.dumps(payload, separators=(",", ":")), encoding="utf-8"
+        )
+
+
+def build_local_exports(
+    start_date: str,
+    end_date: str,
+    out_dir: Path,
+    fleet: tuple[FleetAsset, ...] = FLEET,
+    use_real_weather: bool = True,
+    random_seed: int = 42,
+) -> dict[str, Any]:
+    """Simulate the fleet and write the dashboard exports; return the manifest."""
+    result = simulate_fleet(start_date, end_date, fleet, use_real_weather, random_seed)
+    bundle = build_bundle(result, fleet)
+    write_bundle(bundle, out_dir)
+    return bundle.manifest
+
+
+__all__ = [
+    "SCHEMA_VERSION",
+    "ExportBundle",
+    "build_bundle",
+    "build_local_exports",
+    "write_bundle",
+]

--- a/src/weather_analytics/mock_data/physics.py
+++ b/src/weather_analytics/mock_data/physics.py
@@ -1,0 +1,353 @@
+"""Vectorized plant-physics models for the fleet simulator.
+
+Pure functions over numpy arrays — no I/O, no global state — so they are cheap
+to unit-test and reuse. Wind and solar are fully vectorized; battery and gas
+dispatch are inherently sequential (state at hour *t* depends on *t-1*) and use
+an explicit scan.
+
+References (verified 2026-07): IEC 61400-12-1 air-density correction; Sandia
+PVPMC NOCT cell-temperature model; PVWatts v8 14% system-loss default;
+Ornstein-Uhlenbeck / AR(1) equivalence for autocorrelated wind noise; EIA fleet
+capacity factors for sanity checks.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from weather_analytics.mock_data.fleet import (
+    CO2_TONNES_PER_MMBTU,
+    BatteryParams,
+    GasParams,
+    SolarParams,
+    WindParams,
+)
+
+# Physical constants.
+_R_SPECIFIC_DRY_AIR = 287.05  # J/(kg*K)
+_RHO_REF = 1.225  # kg/m^3 at 15 C, sea level (IEC reference density)
+_STC_IRRADIANCE = 1000.0  # W/m^2
+_STC_CELL_TEMP_C = 25.0
+_NOCT_IRRADIANCE = 800.0
+_NOCT_AMBIENT_C = 20.0
+
+
+def air_density(temperature_c: np.ndarray, pressure_hpa: np.ndarray) -> np.ndarray:
+    """Air density (kg/m^3) from the ideal gas law.
+
+    Parameters
+    ----------
+    temperature_c : np.ndarray
+        Air temperature (°C).
+    pressure_hpa : np.ndarray
+        Surface pressure (hPa).
+
+    Returns
+    -------
+    np.ndarray
+        Air density (kg/m^3).
+    """
+    temp_k = temperature_c + 273.15
+    pressure_pa = pressure_hpa * 100.0
+    return pressure_pa / (_R_SPECIFIC_DRY_AIR * temp_k)
+
+
+def ar1_noise(
+    n: int,
+    phi: float,
+    sigma_stationary: float,
+    rng: np.random.Generator,
+) -> np.ndarray:
+    """Generate an AR(1) (discretely-sampled Ornstein-Uhlenbeck) noise series.
+
+    ``x_t = phi * x_{t-1} + eps_t`` with ``eps_t ~ N(0, sigma_eps^2)`` chosen so
+    the stationary std equals ``sigma_stationary``. The initial sample is drawn
+    from the stationary distribution to avoid a warm-up transient.
+
+    Parameters
+    ----------
+    n : int
+        Number of samples.
+    phi : float
+        Autocorrelation coefficient in (0, 1). Higher == more persistent.
+    sigma_stationary : float
+        Target stationary standard deviation of the series.
+    rng : np.random.Generator
+        Random source.
+
+    Returns
+    -------
+    np.ndarray
+        Length-``n`` autocorrelated noise series.
+    """
+    if n <= 0:
+        return np.zeros(0)
+    sigma_eps = sigma_stationary * np.sqrt(1.0 - phi**2)
+    innovations = rng.normal(0.0, sigma_eps, n)
+    out = np.empty(n)
+    out[0] = rng.normal(0.0, sigma_stationary)
+    for t in range(1, n):
+        out[t] = phi * out[t - 1] + innovations[t]
+    return out
+
+
+def wind_power_mwh(
+    wind_speed_mps: np.ndarray,
+    temperature_c: np.ndarray,
+    pressure_hpa: np.ndarray,
+    capacity_mw: float,
+    params: WindParams,
+    rng: np.random.Generator,
+    phi: float = 0.85,
+) -> np.ndarray:
+    """Wind farm hourly output (MWh) from a piecewise power curve.
+
+    Applies AR(1) turbulence to the wind speed, the normalized cubic power
+    curve, an air-density multiplier, and wake + availability losses.
+
+    Parameters
+    ----------
+    wind_speed_mps : np.ndarray
+        Hub-height wind speed (m/s).
+    temperature_c, pressure_hpa : np.ndarray
+        Weather used for the air-density correction.
+    capacity_mw : float
+        Nameplate capacity (MW).
+    params : WindParams
+        Power-curve and loss parameters.
+    rng : np.random.Generator
+        Random source for the turbulence noise.
+    phi : float
+        AR(1) persistence for the turbulence series.
+
+    Returns
+    -------
+    np.ndarray
+        Hourly generation (MWh) after losses.
+    """
+    n = wind_speed_mps.shape[0]
+    turbulence = ar1_noise(n, phi, params.turbulence_intensity, rng)
+    speed = np.clip(wind_speed_mps * (1.0 + turbulence), 0.0, None)
+
+    cut_in, rated, cut_out = params.cut_in_mps, params.rated_mps, params.cut_out_mps
+    fraction = np.zeros(n)
+
+    ramp = (speed >= cut_in) & (speed < rated)
+    fraction[ramp] = (speed[ramp] ** 3 - cut_in**3) / (rated**3 - cut_in**3)
+
+    flat = (speed >= rated) & (speed <= cut_out)
+    fraction[flat] = 1.0
+    # Above cut-out and below cut-in stay 0.
+
+    density_ratio = air_density(temperature_c, pressure_hpa) / _RHO_REF
+    loss_factor = (1.0 - params.wake_loss) * params.availability
+    return capacity_mw * fraction * density_ratio * loss_factor
+
+
+def solar_power_mwh(
+    ghi: np.ndarray,
+    temperature_c: np.ndarray,
+    cloud_cover_pct: np.ndarray,
+    capacity_mw: float,
+    params: SolarParams,
+    rng: np.random.Generator,
+    phi: float = 0.7,
+) -> np.ndarray:
+    """Solar PV hourly AC output (MWh) with NOCT derate and inverter clipping.
+
+    ``capacity_mw`` is the AC (inverter) rating. DC nameplate is
+    ``capacity_mw * dc_ac_ratio``; DC power above the AC rating is clipped.
+
+    Parameters
+    ----------
+    ghi : np.ndarray
+        Global horizontal irradiance (W/m^2).
+    temperature_c : np.ndarray
+        Ambient air temperature (°C).
+    cloud_cover_pct : np.ndarray
+        Total cloud cover (%), used for sub-hourly transient variability.
+    capacity_mw : float
+        AC (inverter) nameplate rating (MW).
+    params : SolarParams
+        PV system parameters.
+    rng : np.random.Generator
+        Random source for cloud-transient noise.
+    phi : float
+        AR(1) persistence for the cloud-transient series.
+
+    Returns
+    -------
+    np.ndarray
+        Hourly AC generation (MWh) after clipping and system derate.
+    """
+    n = ghi.shape[0]
+    # Cloud-transient modulation: largest at partial cloud, ~0 when clear/overcast.
+    cloud_frac = np.clip(cloud_cover_pct / 100.0, 0.0, 1.0)
+    transient = np.clip(0.5 + ar1_noise(n, phi, 0.5, rng), 0.0, 1.0)
+    ghi_eff = np.clip(ghi * (1.0 - 0.8 * cloud_frac * transient), 0.0, None)
+
+    cell_temp = (
+        temperature_c + ((params.noct_c - _NOCT_AMBIENT_C) / _NOCT_IRRADIANCE) * ghi_eff
+    )
+    temp_factor = 1.0 + params.temp_coeff_per_c * (cell_temp - _STC_CELL_TEMP_C)
+
+    dc_nameplate = capacity_mw * params.dc_ac_ratio
+    p_dc = dc_nameplate * (ghi_eff / _STC_IRRADIANCE) * temp_factor
+    p_ac = np.minimum(p_dc * params.system_derate, capacity_mw)
+    return np.clip(p_ac, 0.0, None)
+
+
+def battery_dispatch(
+    signal: np.ndarray,
+    capacity_mw: float,
+    params: BatteryParams,
+    charge_threshold: float,
+    discharge_threshold: float,
+) -> dict[str, np.ndarray]:
+    """Sequential SOC dispatch against a normalized price/net-load signal.
+
+    Charges when the signal is below ``charge_threshold`` (cheap/surplus power)
+    and discharges when above ``discharge_threshold`` (expensive/peak), subject
+    to power, SOC-window, and round-trip-efficiency constraints. A small
+    parasitic load is drawn every hour.
+
+    Parameters
+    ----------
+    signal : np.ndarray
+        Normalized dispatch signal in [0, 1] (e.g. percentile of net load).
+    capacity_mw : float
+        Rated power (MW).
+    params : BatteryParams
+        Storage parameters.
+    charge_threshold, discharge_threshold : float
+        Signal thresholds bounding the idle band.
+
+    Returns
+    -------
+    dict[str, np.ndarray]
+        ``charge_mwh``, ``discharge_mwh``, ``net_mwh`` (discharge - charge),
+        and ``soc_pct`` (0-100) per hour.
+    """
+    n = signal.shape[0]
+    energy_max = capacity_mw * params.duration_h
+    soc_min = params.soc_min_frac * energy_max
+    soc_max = params.soc_max_frac * energy_max
+    eta = np.sqrt(params.round_trip_efficiency)  # symmetric charge/discharge leg
+    aux = params.aux_load_frac * capacity_mw
+
+    charge = np.zeros(n)
+    discharge = np.zeros(n)
+    soc_pct = np.zeros(n)
+    soc = 0.5 * energy_max  # start half full
+
+    for t in range(n):
+        soc = max(soc - aux, soc_min)  # parasitic draw first
+        if signal[t] < charge_threshold and soc < soc_max:
+            headroom = (soc_max - soc) / eta
+            power = min(capacity_mw, headroom)
+            charge[t] = power
+            soc += eta * power
+        elif signal[t] > discharge_threshold and soc > soc_min:
+            available = (soc - soc_min) * eta
+            power = min(capacity_mw, available)
+            discharge[t] = power
+            soc -= power / eta
+        soc = min(max(soc, soc_min), soc_max)
+        soc_pct[t] = soc / energy_max * 100.0
+
+    return {
+        "charge_mwh": charge,
+        "discharge_mwh": discharge,
+        "net_mwh": discharge - charge,
+        "soc_pct": soc_pct,
+    }
+
+
+def _part_load_heat_rate(load_frac: np.ndarray, params: GasParams) -> np.ndarray:
+    """Heat rate (Btu/kWh) as a function of load fraction; convex penalty."""
+    safe = np.where(load_frac > 0.0, load_frac, 1.0)
+    return params.heat_rate_btu_kwh * (params.part_load_a + params.part_load_b / safe)
+
+
+def gas_dispatch(
+    signal: np.ndarray,
+    capacity_mw: float,
+    params: GasParams,
+    dispatch_threshold: float,
+    rng: np.random.Generator,
+) -> dict[str, np.ndarray]:
+    """Sequential merit-order gas dispatch with ramping, min load, and outages.
+
+    Dispatches toward a target set by the residual-load/price ``signal`` when it
+    clears ``dispatch_threshold``, honoring minimum stable load, hourly ramp
+    limits, and stochastic forced outages. Computes fuel burn (part-load heat
+    rate) and CO2.
+
+    Parameters
+    ----------
+    signal : np.ndarray
+        Normalized residual-load/price signal in [0, 1].
+    capacity_mw : float
+        Nameplate capacity (MW).
+    params : GasParams
+        Gas-unit parameters.
+    dispatch_threshold : float
+        Signal level above which the unit is called on.
+    rng : np.random.Generator
+        Random source for forced-outage sampling.
+
+    Returns
+    -------
+    dict[str, np.ndarray]
+        ``net_mwh``, ``fuel_mmbtu``, ``heat_rate_btu_kwh``, ``co2_tonnes``,
+        and ``online`` (1.0 when not in a forced outage) per hour.
+    """
+    n = signal.shape[0]
+    min_load = params.min_load_frac * capacity_mw
+    ramp_limit = params.ramp_frac_per_hr * capacity_mw
+    outage = np.asarray(rng.random(n) < params.forced_outage_rate)
+
+    output = np.zeros(n)
+    prev = 0.0
+    for t in range(n):
+        if outage[t]:
+            target = 0.0
+        elif signal[t] > dispatch_threshold:
+            # Scale from min load to full capacity across the callable band.
+            span = max(1.0 - dispatch_threshold, 1e-6)
+            frac = (signal[t] - dispatch_threshold) / span
+            target = min_load + frac * (capacity_mw - min_load)
+        else:
+            target = 0.0
+        # Ramp constraint relative to previous hour.
+        lo, hi = prev - ramp_limit, prev + ramp_limit
+        power = float(np.clip(target, max(0.0, lo), hi))
+        if 0.0 < power < min_load:
+            power = 0.0  # never run below min stable load
+        output[t] = power
+        prev = power
+
+    load_frac = np.where(capacity_mw > 0, output / capacity_mw, 0.0)
+    heat_rate = np.where(
+        output > 0, _part_load_heat_rate(load_frac, params), params.heat_rate_btu_kwh
+    )
+    fuel_mmbtu = output * heat_rate / 1000.0  # Btu/kWh * MWh = kBtu -> MMBtu/1000
+    co2_tonnes = fuel_mmbtu * CO2_TONNES_PER_MMBTU
+    online = np.where(outage, 0.0, 1.0)
+    return {
+        "net_mwh": output,
+        "fuel_mmbtu": fuel_mmbtu,
+        "heat_rate_btu_kwh": heat_rate,
+        "co2_tonnes": co2_tonnes,
+        "online": online,
+    }
+
+
+__all__ = [
+    "air_density",
+    "ar1_noise",
+    "battery_dispatch",
+    "gas_dispatch",
+    "solar_power_mwh",
+    "wind_power_mwh",
+]

--- a/src/weather_analytics/mock_data/simulate.py
+++ b/src/weather_analytics/mock_data/simulate.py
@@ -1,0 +1,327 @@
+"""Fleet simulation: weather + physics -> unified hourly generation frame.
+
+Ties the pieces together with a physically-motivated merit order:
+
+1. Wind and solar output are computed from the (real or synthetic) weather.
+2. A synthetic system demand curve defines net load = demand - renewables.
+3. Batteries dispatch against net load (charge on surplus, discharge on peak).
+4. Gas units fill the residual after storage (CCGT mid-merit, peaker on top).
+5. Renewable oversupply (renewables > demand) is booked as curtailment.
+
+The result is one long-format frame with a shared core schema plus nullable,
+technology-specific columns (battery SOC/throughput, gas fuel/heat-rate/CO2).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+import polars as pl
+
+from weather_analytics.mock_data import physics
+from weather_analytics.mock_data.fleet import (
+    BATTERY,
+    FLEET,
+    GAS,
+    SOLAR,
+    WIND,
+    FleetAsset,
+)
+from weather_analytics.mock_data.weather_sources import get_weather
+
+# Core + technology-specific columns emitted by the simulation.
+GENERATION_COLUMNS: tuple[str, ...] = (
+    "timestamp",
+    "asset_id",
+    "asset_type",
+    "gross_generation_mwh",
+    "net_generation_mwh",
+    "curtailment_mwh",
+    "availability_pct",
+    "asset_capacity_mw",
+    "soc_pct",
+    "charge_mwh",
+    "discharge_mwh",
+    "fuel_mmbtu",
+    "heat_rate_btu_kwh",
+    "co2_tonnes",
+)
+
+
+@dataclass(frozen=True)
+class SimulationResult:
+    """Bundle of the simulation outputs.
+
+    Attributes
+    ----------
+    generation : pl.DataFrame
+        Long-format hourly generation in :data:`GENERATION_COLUMNS`.
+    weather : pl.DataFrame
+        The weather frame that drove the simulation.
+    weather_source : str
+        ``"open-meteo"`` or ``"synthetic"``.
+    """
+
+    generation: pl.DataFrame
+    weather: pl.DataFrame
+    weather_source: str
+
+
+def _rank_signal(values: np.ndarray) -> np.ndarray:
+    """Map an array to its [0, 1] rank percentile (stable dispatch signal)."""
+    n = values.shape[0]
+    if n == 0:
+        return values
+    order = values.argsort()
+    ranks = np.empty(n)
+    ranks[order] = np.arange(n)
+    return np.asarray(ranks / max(n - 1, 1))
+
+
+def _demand_curve(timestamps: pl.Series, scale_mw: float) -> np.ndarray:
+    """Synthetic system demand (MW): diurnal + seasonal shape, evening peak."""
+    hours = timestamps.dt.hour().to_numpy()
+    doy = timestamps.dt.ordinal_day().to_numpy()
+    diurnal = 0.72 + 0.20 * np.sin(2 * np.pi * (hours - 17) / 24)
+    # Summer + winter peaks (cooling/heating), spring/fall troughs.
+    seasonal = 1.0 + 0.12 * np.cos(4 * np.pi * (doy - 15) / 365)
+    return scale_mw * diurnal * seasonal
+
+
+def _wind_solar_frame(
+    asset: FleetAsset,
+    weather: pl.DataFrame,
+    rng: np.random.Generator,
+) -> tuple[pl.DataFrame, np.ndarray]:
+    """Compute a wind/solar asset's potential output; return (frame, potential)."""
+    w = weather.filter(pl.col("asset_id") == asset.asset_id).sort("timestamp")
+    ts = w["timestamp"]
+    temp = w["temperature_c"].to_numpy()
+    if asset.asset_type == WIND:
+        assert asset.wind is not None
+        potential = physics.wind_power_mwh(
+            w["wind_speed_mps"].to_numpy(),
+            temp,
+            w["pressure_hpa"].to_numpy(),
+            asset.capacity_mw,
+            asset.wind,
+            rng,
+        )
+    else:
+        assert asset.solar is not None
+        potential = physics.solar_power_mwh(
+            w["ghi"].to_numpy(),
+            temp,
+            w["cloud_cover_pct"].to_numpy(),
+            asset.capacity_mw,
+            asset.solar,
+            rng,
+        )
+    availability = np.clip(rng.normal(96.0, 3.0, len(ts)), 85.0, 100.0)
+    frame = pl.DataFrame(
+        {"timestamp": ts, "_potential": potential, "_availability": availability}
+    )
+    return frame, potential
+
+
+def simulate_fleet(
+    start_date: str,
+    end_date: str,
+    assets: tuple[FleetAsset, ...] = FLEET,
+    use_real_weather: bool = True,
+    random_seed: int = 42,
+) -> SimulationResult:
+    """Run the full hourly fleet simulation.
+
+    Parameters
+    ----------
+    start_date, end_date : str
+        ISO datetimes (inclusive) at hourly resolution.
+    assets : tuple[FleetAsset, ...]
+        Fleet to simulate. Defaults to :data:`FLEET`.
+    use_real_weather : bool
+        Attempt an Open-Meteo pull before falling back to synthetic weather.
+    random_seed : int
+        Seed for all stochastic components.
+
+    Returns
+    -------
+    SimulationResult
+        Generation frame, weather frame, and weather provenance.
+    """
+    rng = np.random.default_rng(random_seed)
+    weather, source = get_weather(
+        assets, start_date, end_date, use_real_weather, random_seed
+    )
+
+    timestamps = weather.select("timestamp").unique().sort("timestamp")["timestamp"]
+    n = len(timestamps)
+    ts_index = {t: i for i, t in enumerate(timestamps.to_list())}
+
+    wind_solar = [a for a in assets if a.asset_type in (WIND, SOLAR)]
+    batteries = [a for a in assets if a.asset_type == BATTERY]
+    gas_units = [a for a in assets if a.asset_type == GAS]
+
+    # --- 1. Wind + solar potential, aligned on the shared time axis ---
+    potentials: dict[str, np.ndarray] = {}
+    availabilities: dict[str, np.ndarray] = {}
+    total_renewable = np.zeros(n)
+    for asset in wind_solar:
+        frame, potential = _wind_solar_frame(asset, weather, rng)
+        idx = np.array([ts_index[t] for t in frame["timestamp"].to_list()])
+        aligned = np.zeros(n)
+        aligned[idx] = potential
+        avail = np.full(n, 96.0)
+        avail[idx] = frame["_availability"].to_numpy()
+        potentials[asset.asset_id] = aligned
+        availabilities[asset.asset_id] = avail
+        total_renewable += aligned
+
+    # --- 2. Demand + net load ---
+    supply_scale = sum(a.capacity_mw for a in wind_solar + gas_units) or 1.0
+    demand = _demand_curve(timestamps, supply_scale * 0.55)
+    net_load_after_re = demand - total_renewable
+
+    # --- 3. Battery dispatch against net load ---
+    battery_signal = _rank_signal(net_load_after_re)
+    battery_out: dict[str, dict[str, np.ndarray]] = {}
+    total_battery_net = np.zeros(n)
+    for asset in batteries:
+        assert asset.battery is not None
+        out = physics.battery_dispatch(
+            battery_signal,
+            asset.capacity_mw,
+            asset.battery,
+            charge_threshold=0.35,
+            discharge_threshold=0.65,
+        )
+        battery_out[asset.asset_id] = out
+        total_battery_net += out["net_mwh"]
+
+    # --- 4. Gas dispatch against residual after storage ---
+    net_load_after_batt = net_load_after_re - total_battery_net
+    gas_signal = _rank_signal(net_load_after_batt)
+    gas_out: dict[str, dict[str, np.ndarray]] = {}
+    for asset in gas_units:
+        assert asset.gas is not None
+        threshold = 0.35 if asset.gas.subtype == "ccgt" else 0.80
+        gas_out[asset.asset_id] = physics.gas_dispatch(
+            gas_signal,
+            asset.capacity_mw,
+            asset.gas,
+            threshold,
+            rng,
+        )
+
+    # --- 5. Renewable curtailment on oversupply ---
+    oversupply = np.clip(total_renewable - demand, 0.0, None)
+    curtail_share = np.where(total_renewable > 0, oversupply / total_renewable, 0.0)
+
+    rows: list[pl.DataFrame] = []
+    ts_list = timestamps
+
+    for asset in wind_solar:
+        potential = potentials[asset.asset_id]
+        curtailment = potential * curtail_share
+        net = np.clip(potential - curtailment, 0.0, None)
+        rows.append(
+            _core_frame(
+                ts_list,
+                asset,
+                gross=potential,
+                net=net,
+                curtailment=curtailment,
+                availability=availabilities[asset.asset_id],
+            )
+        )
+
+    for asset in batteries:
+        out = battery_out[asset.asset_id]
+        rows.append(
+            _core_frame(
+                ts_list,
+                asset,
+                gross=out["discharge_mwh"],
+                net=out["net_mwh"],
+                curtailment=np.zeros(n),
+                availability=np.full(n, 98.0),
+                soc_pct=out["soc_pct"],
+                charge=out["charge_mwh"],
+                discharge=out["discharge_mwh"],
+            )
+        )
+
+    for asset in gas_units:
+        out = gas_out[asset.asset_id]
+        rows.append(
+            _core_frame(
+                ts_list,
+                asset,
+                gross=out["net_mwh"],
+                net=out["net_mwh"],
+                curtailment=np.zeros(n),
+                availability=85.0 + 15.0 * out["online"],
+                fuel=out["fuel_mmbtu"],
+                heat_rate=out["heat_rate_btu_kwh"],
+                co2=out["co2_tonnes"],
+            )
+        )
+
+    generation = (
+        pl.concat(rows).select(GENERATION_COLUMNS).sort(["timestamp", "asset_id"])
+    )
+    return SimulationResult(generation, weather, source)
+
+
+def _core_frame(
+    timestamps: pl.Series,
+    asset: FleetAsset,
+    *,
+    gross: np.ndarray,
+    net: np.ndarray,
+    curtailment: np.ndarray,
+    availability: np.ndarray,
+    soc_pct: np.ndarray | None = None,
+    charge: np.ndarray | None = None,
+    discharge: np.ndarray | None = None,
+    fuel: np.ndarray | None = None,
+    heat_rate: np.ndarray | None = None,
+    co2: np.ndarray | None = None,
+) -> pl.DataFrame:
+    """Assemble one asset's rows in the unified schema (nulls where N/A)."""
+    n = len(timestamps)
+    nulls: list[float | None] = [None] * n
+
+    def _opt(arr: np.ndarray | None) -> list[float | None]:
+        return nulls if arr is None else [float(x) for x in arr]
+
+    return pl.DataFrame(
+        {
+            "timestamp": timestamps,
+            "asset_id": [asset.asset_id] * n,
+            "asset_type": [asset.asset_type] * n,
+            "gross_generation_mwh": gross.tolist(),
+            "net_generation_mwh": net.tolist(),
+            "curtailment_mwh": curtailment.tolist(),
+            "availability_pct": availability.tolist(),
+            "asset_capacity_mw": [asset.capacity_mw] * n,
+            "soc_pct": _opt(soc_pct),
+            "charge_mwh": _opt(charge),
+            "discharge_mwh": _opt(discharge),
+            "fuel_mmbtu": _opt(fuel),
+            "heat_rate_btu_kwh": _opt(heat_rate),
+            "co2_tonnes": _opt(co2),
+        },
+        schema_overrides={
+            "soc_pct": pl.Float64,
+            "charge_mwh": pl.Float64,
+            "discharge_mwh": pl.Float64,
+            "fuel_mmbtu": pl.Float64,
+            "heat_rate_btu_kwh": pl.Float64,
+            "co2_tonnes": pl.Float64,
+        },
+    )
+
+
+__all__ = ["GENERATION_COLUMNS", "SimulationResult", "simulate_fleet"]

--- a/src/weather_analytics/mock_data/weather_sources.py
+++ b/src/weather_analytics/mock_data/weather_sources.py
@@ -1,0 +1,255 @@
+"""Weather inputs for the fleet simulator: real (Open-Meteo) or synthetic.
+
+The simulator is driven by one hourly weather frame covering every asset site.
+When network access is available, :func:`fetch_open_meteo` pulls genuine ERA5
+reanalysis hourly data from the free Open-Meteo archive API (no key). When it is
+not — offline CI, air-gapped runs, an API hiccup — :func:`synthetic_weather`
+produces a latitude-aware physical stand-in so the pipeline always runs.
+
+Both return the same schema::
+
+    timestamp, asset_id, wind_speed_mps, wind_direction_deg, ghi,
+    temperature_c, pressure_hpa, relative_humidity, cloud_cover_pct
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+
+import numpy as np
+import polars as pl
+import requests  # type: ignore[import-untyped]
+
+from weather_analytics.mock_data.fleet import FleetAsset
+
+logger = logging.getLogger(__name__)
+
+_ARCHIVE_URL = "https://archive-api.open-meteo.com/v1/archive"
+_HOURLY_VARS = (
+    "wind_speed_100m",
+    "wind_direction_100m",
+    "shortwave_radiation",
+    "temperature_2m",
+    "surface_pressure",
+    "relative_humidity_2m",
+    "cloud_cover",
+)
+
+WEATHER_COLUMNS: tuple[str, ...] = (
+    "timestamp",
+    "asset_id",
+    "wind_speed_mps",
+    "wind_direction_deg",
+    "ghi",
+    "temperature_c",
+    "pressure_hpa",
+    "relative_humidity",
+    "cloud_cover_pct",
+)
+
+
+def _fetch_one(
+    asset: FleetAsset, start_date: str, end_date: str, timeout: float
+) -> pl.DataFrame:
+    """Fetch one asset's hourly archive series and map to the local schema."""
+    params = {
+        "latitude": asset.latitude,
+        "longitude": asset.longitude,
+        "start_date": start_date[:10],
+        "end_date": end_date[:10],
+        "hourly": ",".join(_HOURLY_VARS),
+        "wind_speed_unit": "ms",
+        "timezone": "auto",
+    }
+    response = requests.get(_ARCHIVE_URL, params=params, timeout=timeout)
+    response.raise_for_status()
+    hourly = response.json()["hourly"]
+
+    times = [datetime.fromisoformat(t) for t in hourly["time"]]
+
+    def _col(key: str, default: float) -> list[float]:
+        return [default if v is None else float(v) for v in hourly[key]]
+
+    return pl.DataFrame(
+        {
+            "timestamp": times,
+            "asset_id": [asset.asset_id] * len(times),
+            "wind_speed_mps": _col("wind_speed_100m", 0.0),
+            "wind_direction_deg": _col("wind_direction_100m", 0.0),
+            "ghi": _col("shortwave_radiation", 0.0),
+            "temperature_c": _col("temperature_2m", 15.0),
+            "pressure_hpa": _col("surface_pressure", 1013.0),
+            "relative_humidity": _col("relative_humidity_2m", 60.0),
+            "cloud_cover_pct": _col("cloud_cover", 0.0),
+        }
+    )
+
+
+def fetch_open_meteo(
+    assets: tuple[FleetAsset, ...] | list[FleetAsset],
+    start_date: str,
+    end_date: str,
+    timeout: float = 30.0,
+) -> pl.DataFrame | None:
+    """Fetch real hourly weather for every asset from the Open-Meteo archive.
+
+    Parameters
+    ----------
+    assets : sequence of FleetAsset
+        Fleet whose coordinates drive the per-site requests.
+    start_date, end_date : str
+        ISO datetimes (only the date portion is used by the archive API).
+    timeout : float
+        Per-request timeout in seconds.
+
+    Returns
+    -------
+    pl.DataFrame | None
+        Combined weather frame, or ``None`` if any request fails (caller falls
+        back to synthetic weather).
+    """
+    frames: list[pl.DataFrame] = []
+    try:
+        for asset in assets:
+            frames.append(_fetch_one(asset, start_date, end_date, timeout))
+    except (requests.RequestException, KeyError, ValueError) as exc:
+        logger.warning("Open-Meteo fetch failed (%s); using synthetic weather", exc)
+        return None
+    if not frames:
+        return None
+    logger.info("Fetched real Open-Meteo weather for %d assets", len(frames))
+    return pl.concat(frames).select(WEATHER_COLUMNS).sort(["timestamp", "asset_id"])
+
+
+def synthetic_weather(
+    assets: tuple[FleetAsset, ...] | list[FleetAsset],
+    start_date: str,
+    end_date: str,
+    random_seed: int = 42,
+) -> pl.DataFrame:
+    """Latitude-aware synthetic hourly weather (offline fallback).
+
+    Physically-plausible seasonal + diurnal signals with autocorrelated noise,
+    parameterized by each site's latitude so Southwest solar sites are hotter
+    and sunnier than northern wind sites.
+
+    Parameters
+    ----------
+    assets : sequence of FleetAsset
+        Fleet to generate weather for.
+    start_date, end_date : str
+        ISO datetimes (inclusive) at hourly resolution.
+    random_seed : int
+        Seed for reproducibility.
+
+    Returns
+    -------
+    pl.DataFrame
+        Weather frame in :data:`WEATHER_COLUMNS` order.
+    """
+    rng = np.random.default_rng(random_seed)
+    timestamps = pl.datetime_range(
+        start=datetime.fromisoformat(start_date),
+        end=datetime.fromisoformat(end_date),
+        interval="1h",
+        eager=True,
+    )
+    hours = timestamps.dt.hour().to_numpy()
+    doy = timestamps.dt.ordinal_day().to_numpy()
+    n = len(timestamps)
+
+    frames: list[pl.DataFrame] = []
+    for asset in assets:
+        lat = asset.latitude
+        # Clear-sky GHI from solar geometry: declination + zenith angle. This
+        # gives physically-correct seasonal daylight length and peak irradiance
+        # (short, weak winter days; long, strong summer days) per latitude.
+        declination = np.radians(
+            23.45 * np.sin(np.radians(360.0 * (284 + doy) / 365.0))
+        )
+        hour_angle = np.radians(15.0 * (hours - 12.0))
+        lat_rad = np.radians(lat)
+        cos_zenith = np.clip(
+            np.sin(lat_rad) * np.sin(declination)
+            + np.cos(lat_rad) * np.cos(declination) * np.cos(hour_angle),
+            0.0,
+            None,
+        )
+        ghi_clear = 1050.0 * cos_zenith  # clear-sky peak ~1050 W/m^2
+        cloud = np.clip(
+            35 + 25 * np.sin(2 * np.pi * doy / 365 + lat) + rng.normal(0, 18, n),
+            0,
+            100,
+        )
+        ghi = np.clip(ghi_clear * (1 - 0.7 * cloud / 100), 0, None)
+
+        # Wind: windier at higher latitudes/plains, seasonal + diurnal + noise.
+        base_wind = 6.5 + 0.06 * abs(lat - 25)
+        seasonal_wind = base_wind + 2.5 * np.sin(2 * np.pi * (doy - 30) / 365)
+        diurnal_wind = 1.5 * np.sin(2 * np.pi * (hours - 15) / 24)
+        wind = np.clip(seasonal_wind + diurnal_wind + rng.normal(0, 2.5, n), 0.0, 28.0)
+        wind_dir = (rng.uniform(0, 360) + rng.normal(0, 25, n)) % 360
+
+        # Temperature: warmer at lower latitudes.
+        base_temp = 28 - 0.55 * (lat - 25)
+        temp = (
+            base_temp
+            + 12 * np.sin(2 * np.pi * (doy - 110) / 365)
+            + 6 * np.sin(2 * np.pi * (hours - 15) / 24)
+            + rng.normal(0, 2.2, n)
+        )
+        pressure = 1013 + 5 * np.sin(2 * np.pi * doy / 365) + rng.normal(0, 5, n)
+        humidity = np.clip(
+            62 - 0.4 * (temp - 15) - 0.012 * ghi + rng.normal(0, 9, n), 15, 98
+        )
+
+        frames.append(
+            pl.DataFrame(
+                {
+                    "timestamp": timestamps,
+                    "asset_id": [asset.asset_id] * n,
+                    "wind_speed_mps": wind,
+                    "wind_direction_deg": wind_dir,
+                    "ghi": ghi,
+                    "temperature_c": temp,
+                    "pressure_hpa": pressure,
+                    "relative_humidity": humidity,
+                    "cloud_cover_pct": cloud,
+                }
+            )
+        )
+    return pl.concat(frames).select(WEATHER_COLUMNS).sort(["timestamp", "asset_id"])
+
+
+def get_weather(
+    assets: tuple[FleetAsset, ...] | list[FleetAsset],
+    start_date: str,
+    end_date: str,
+    use_real: bool = True,
+    random_seed: int = 42,
+) -> tuple[pl.DataFrame, str]:
+    """Return hourly weather and its provenance label.
+
+    Tries Open-Meteo when ``use_real`` is set, falling back to synthetic weather
+    on any failure so the caller always gets a usable frame.
+
+    Returns
+    -------
+    tuple[pl.DataFrame, str]
+        ``(weather_df, source)`` where source is ``"open-meteo"`` or
+        ``"synthetic"``.
+    """
+    if use_real:
+        real = fetch_open_meteo(assets, start_date, end_date)
+        if real is not None and real.height > 0:
+            return real, "open-meteo"
+    return synthetic_weather(assets, start_date, end_date, random_seed), "synthetic"
+
+
+__all__ = [
+    "WEATHER_COLUMNS",
+    "fetch_open_meteo",
+    "get_weather",
+    "synthetic_weather",
+]

--- a/tests/unit/test_fleet.py
+++ b/tests/unit/test_fleet.py
@@ -1,0 +1,65 @@
+"""Unit tests for the fleet registry."""
+
+from __future__ import annotations
+
+import pytest
+
+from weather_analytics.mock_data.fleet import (
+    ASSET_TYPES,
+    BATTERY,
+    FLEET,
+    FLEET_BY_ID,
+    GAS,
+    SOLAR,
+    WIND,
+    FleetAsset,
+    assets_of_type,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def test_fleet_has_all_four_technologies() -> None:
+    types = {a.asset_type for a in FLEET}
+    assert types == set(ASSET_TYPES)
+
+
+def test_fleet_type_counts() -> None:
+    counts = {t: len(assets_of_type(t)) for t in ASSET_TYPES}
+    assert counts == {WIND: 4, SOLAR: 4, BATTERY: 2, GAS: 2}
+
+
+def test_each_asset_has_exactly_one_params_object() -> None:
+    for a in FLEET:
+        populated = [p for p in (a.wind, a.solar, a.battery, a.gas) if p is not None]
+        assert len(populated) == 1, a.asset_id
+        # The populated params must match the declared type.
+        expected = {WIND: a.wind, SOLAR: a.solar, BATTERY: a.battery, GAS: a.gas}
+        assert expected[a.asset_type] is not None
+
+
+def test_asset_ids_unique_and_indexed() -> None:
+    ids = [a.asset_id for a in FLEET]
+    assert len(ids) == len(set(ids))
+    assert set(FLEET_BY_ID) == set(ids)
+
+
+def test_coordinates_are_plausible_us_sites() -> None:
+    for a in FLEET:
+        assert 24.0 <= a.latitude <= 49.0, a.asset_id
+        assert -125.0 <= a.longitude <= -66.0, a.asset_id
+
+
+@pytest.mark.parametrize(
+    ("mw", "expected"),
+    [(80.0, "Large"), (75.0, "Large"), (60.0, "Medium"), (50.0, "Medium"),
+     (49.0, "Small"), (30.0, "Small")],
+)
+def test_size_category_buckets(mw: float, expected: str) -> None:
+    asset = FleetAsset("X", "Test", WIND, mw, 40.0, -100.0, "TEST")
+    assert asset.size_category == expected
+
+
+def test_display_name_includes_capacity_and_type() -> None:
+    asset = FleetAsset("X", "Roscoe Ridge", WIND, 150.0, 32.0, -100.0, "ERCOT")
+    assert asset.display_name == "Roscoe Ridge (150 MW wind)"

--- a/tests/unit/test_fleet_simulation.py
+++ b/tests/unit/test_fleet_simulation.py
@@ -1,0 +1,120 @@
+"""Unit tests for the fleet simulation and local dashboard export.
+
+All offline: uses synthetic weather so there is no network dependency.
+"""
+
+from __future__ import annotations
+
+import polars as pl
+import pytest
+
+from weather_analytics.mock_data.fleet import FLEET
+from weather_analytics.mock_data.local_export import (
+    SCHEMA_VERSION,
+    build_bundle,
+    build_local_exports,
+)
+from weather_analytics.mock_data.simulate import GENERATION_COLUMNS, simulate_fleet
+
+pytestmark = pytest.mark.unit
+
+_START = "2026-01-01T00:00:00"
+_END = "2026-01-31T23:00:00"  # 31 days
+
+
+@pytest.fixture(scope="module")
+def sim():
+    return simulate_fleet(_START, _END, use_real_weather=False, random_seed=3)
+
+
+def test_generation_schema_and_row_count(sim) -> None:
+    g = sim.generation
+    assert tuple(g.columns) == GENERATION_COLUMNS
+    hours = g.select(pl.col("timestamp").n_unique()).item()
+    assert g.height == hours * len(FLEET)
+    assert sim.weather_source == "synthetic"
+
+
+def test_battery_rows_carry_soc_and_can_go_negative(sim) -> None:
+    battery = sim.generation.filter(pl.col("asset_type") == "battery")
+    assert battery["soc_pct"].null_count() == 0
+    # Storage net energy over a period is negative (round-trip losses).
+    assert battery["net_generation_mwh"].sum() < 0
+
+
+def test_wind_solar_rows_have_null_storage_fields(sim) -> None:
+    ws = sim.generation.filter(pl.col("asset_type").is_in(["wind", "solar"]))
+    assert ws["soc_pct"].null_count() == ws.height
+    assert ws["fuel_mmbtu"].null_count() == ws.height
+
+
+def test_gas_rows_have_fuel_and_co2(sim) -> None:
+    gas = sim.generation.filter(pl.col("asset_type") == "gas")
+    running = gas.filter(pl.col("net_generation_mwh") > 0)
+    assert running["co2_tonnes"].fill_null(0).sum() > 0
+    assert running["fuel_mmbtu"].fill_null(0).sum() > 0
+
+
+def test_capacity_factors_in_realistic_ranges(sim) -> None:
+    g = sim.generation
+    hours = g.select(pl.col("timestamp").n_unique()).item()
+    agg = g.group_by("asset_id").agg(
+        pl.col("net_generation_mwh").sum().alias("net"),
+        pl.col("asset_type").first(),
+        pl.col("asset_capacity_mw").first(),
+    )
+    for r in agg.iter_rows(named=True):
+        cf = r["net"] / (r["asset_capacity_mw"] * hours)
+        if r["asset_type"] == "wind":
+            assert 0.10 <= cf <= 0.55
+        elif r["asset_type"] == "solar":
+            assert 0.05 <= cf <= 0.40
+        elif r["asset_type"] == "gas":
+            assert 0.0 <= cf <= 0.75
+
+
+def test_build_bundle_produces_all_payloads(sim) -> None:
+    bundle = build_bundle(sim, FLEET)
+    n_days = sim.generation.select(pl.col("timestamp").dt.date().n_unique()).item()
+    assert len(bundle.assets) == len(FLEET)
+    assert len(bundle.daily) == len(FLEET) * n_days
+    assert len(bundle.weather) == len(FLEET) * n_days
+    assert bundle.manifest["schema_version"] == SCHEMA_VERSION
+    assert bundle.manifest["asset_type_counts"] == {
+        "wind": 4, "solar": 4, "battery": 2, "gas": 2,
+    }
+
+
+def test_daily_export_has_type_specific_columns(sim) -> None:
+    bundle = build_bundle(sim, FLEET)
+    keys = set(bundle.daily[0])
+    for col in (
+        "asset_type", "avg_soc_pct", "total_discharge_mwh", "total_co2_tonnes",
+        "daily_capacity_factor", "total_net_generation_mwh",
+    ):
+        assert col in keys
+
+
+def test_performance_scores_bounded(sim) -> None:
+    bundle = build_bundle(sim, FLEET)
+    scores = [r["performance_score"] for r in bundle.weather
+              if r["performance_score"] is not None]
+    assert scores
+    assert all(0.0 <= s <= 100.0 for s in scores)
+
+
+def test_inferred_asset_type_uses_actual_type(sim) -> None:
+    bundle = build_bundle(sim, FLEET)
+    types = {r["inferred_asset_type"] for r in bundle.weather}
+    assert types == {"wind", "solar", "battery", "gas"}
+
+
+def test_build_local_exports_writes_four_files(tmp_path) -> None:
+    manifest = build_local_exports(
+        _START, _END, tmp_path, use_real_weather=False, random_seed=3
+    )
+    for name in ("manifest.json", "assets.json", "daily_performance.json",
+                 "weather_performance.json"):
+        assert (tmp_path / name).exists()
+    assert manifest["weather_source"] == "synthetic"
+    assert manifest["asset_count"] == len(FLEET)

--- a/tests/unit/test_physics.py
+++ b/tests/unit/test_physics.py
@@ -1,0 +1,142 @@
+"""Unit tests for the vectorized plant-physics models.
+
+Validates the wind power curve, solar NOCT/clipping model, battery SOC
+dispatch, gas merit-order dispatch, air density, and AR(1) noise against their
+defining physical properties.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from weather_analytics.mock_data import physics
+from weather_analytics.mock_data.fleet import (
+    BatteryParams,
+    GasParams,
+    SolarParams,
+    WindParams,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _rng() -> np.random.Generator:
+    return np.random.default_rng(0)
+
+
+def test_air_density_reference_conditions() -> None:
+    rho = physics.air_density(np.array([15.0]), np.array([1013.25]))
+    assert rho[0] == pytest.approx(1.225, abs=0.01)
+
+
+def test_air_density_rises_when_colder() -> None:
+    cold = physics.air_density(np.array([-10.0]), np.array([1013.0]))
+    warm = physics.air_density(np.array([35.0]), np.array([1013.0]))
+    assert cold[0] > warm[0]
+
+
+def test_ar1_length_and_stationary_std() -> None:
+    series = physics.ar1_noise(20000, phi=0.85, sigma_stationary=0.2, rng=_rng())
+    assert series.shape == (20000,)
+    assert np.std(series) == pytest.approx(0.2, abs=0.03)
+
+
+def test_ar1_zero_length() -> None:
+    assert physics.ar1_noise(0, 0.8, 0.1, _rng()).shape == (0,)
+
+
+def test_wind_zero_below_cut_in_and_above_cut_out() -> None:
+    params = WindParams(turbulence_intensity=0.0)
+    temp = np.array([15.0, 15.0])
+    press = np.array([1013.0, 1013.0])
+    speeds = np.array([2.0, 30.0])  # below cut-in, above cut-out
+    out = physics.wind_power_mwh(speeds, temp, press, 100.0, params, _rng())
+    assert out[0] == pytest.approx(0.0)
+    assert out[1] == pytest.approx(0.0)
+
+
+def test_wind_rated_plateau_applies_losses() -> None:
+    params = WindParams(turbulence_intensity=0.0)
+    speed = np.array([15.0])  # between rated and cut-out -> full fraction
+    out = physics.wind_power_mwh(
+        speed, np.array([15.0]), np.array([1013.0]), 100.0, params, _rng()
+    )
+    # capacity * density(~1) * (1-wake)*avail = 100 * ~1 * 0.9 * 0.95
+    assert out[0] == pytest.approx(100.0 * 0.855, rel=0.05)
+
+
+def test_wind_monotonic_in_ramp_region() -> None:
+    params = WindParams(turbulence_intensity=0.0)
+    speeds = np.array([4.0, 6.0, 8.0, 10.0])
+    temp = np.full(4, 15.0)
+    press = np.full(4, 1013.0)
+    out = physics.wind_power_mwh(speeds, temp, press, 100.0, params, _rng())
+    assert np.all(np.diff(out) > 0)
+
+
+def test_solar_zero_at_night() -> None:
+    out = physics.solar_power_mwh(
+        np.array([0.0]), np.array([20.0]), np.array([0.0]), 50.0,
+        SolarParams(), _rng(),
+    )
+    assert out[0] == pytest.approx(0.0)
+
+
+def test_solar_clips_at_ac_rating() -> None:
+    out = physics.solar_power_mwh(
+        np.array([2000.0]), np.array([25.0]), np.array([0.0]), 50.0,
+        SolarParams(), _rng(),
+    )
+    assert out[0] == pytest.approx(50.0, rel=1e-6)
+
+
+def test_solar_temperature_derate_reduces_output() -> None:
+    hot = physics.solar_power_mwh(
+        np.array([600.0]), np.array([45.0]), np.array([0.0]), 50.0,
+        SolarParams(), _rng(),
+    )
+    cool = physics.solar_power_mwh(
+        np.array([600.0]), np.array([5.0]), np.array([0.0]), 50.0,
+        SolarParams(), _rng(),
+    )
+    assert hot[0] < cool[0]
+
+
+def test_battery_soc_stays_in_window() -> None:
+    signal = np.tile([0.1, 0.9], 200)  # alternate charge / discharge
+    out = physics.battery_dispatch(signal, 50.0, BatteryParams(), 0.35, 0.65)
+    assert out["soc_pct"].min() >= 10.0 - 1e-6
+    assert out["soc_pct"].max() <= 95.0 + 1e-6
+
+
+def test_battery_round_trip_loss() -> None:
+    signal = np.tile([0.1, 0.9], 500)
+    out = physics.battery_dispatch(signal, 50.0, BatteryParams(), 0.35, 0.65)
+    # Energy discharged is less than energy charged (losses on both legs).
+    assert out["discharge_mwh"].sum() < out["charge_mwh"].sum()
+    assert np.allclose(out["net_mwh"], out["discharge_mwh"] - out["charge_mwh"])
+
+
+def test_gas_forced_outage_zeros_output() -> None:
+    params = GasParams(forced_outage_rate=1.0)  # always down
+    signal = np.full(48, 0.99)
+    out = physics.gas_dispatch(signal, 200.0, params, 0.3, _rng())
+    assert np.all(out["net_mwh"] == 0.0)
+    assert np.all(out["online"] == 0.0)
+
+
+def test_gas_respects_min_stable_load() -> None:
+    params = GasParams(forced_outage_rate=0.0, min_load_frac=0.4, ramp_frac_per_hr=1.0)
+    signal = np.linspace(0.0, 1.0, 100)
+    out = physics.gas_dispatch(signal, 200.0, params, 0.3, _rng())
+    running = out["net_mwh"][out["net_mwh"] > 0]
+    assert np.all(running >= 0.4 * 200.0 - 1e-6)
+
+
+def test_gas_fuel_and_co2_track_output() -> None:
+    params = GasParams(forced_outage_rate=0.0)
+    signal = np.full(24, 0.9)
+    out = physics.gas_dispatch(signal, 200.0, params, 0.3, _rng())
+    assert np.all(out["co2_tonnes"][out["net_mwh"] > 0] > 0)
+    assert np.all(out["fuel_mmbtu"][out["net_mwh"] > 0] > 0)

--- a/tests/unit/test_weather_sources.py
+++ b/tests/unit/test_weather_sources.py
@@ -1,0 +1,67 @@
+"""Unit tests for weather sourcing (synthetic + Open-Meteo fallback)."""
+
+from __future__ import annotations
+
+import numpy as np
+import polars as pl
+import pytest
+import requests
+
+from weather_analytics.mock_data import weather_sources
+from weather_analytics.mock_data.fleet import FLEET
+from weather_analytics.mock_data.weather_sources import (
+    WEATHER_COLUMNS,
+    fetch_open_meteo,
+    get_weather,
+    synthetic_weather,
+)
+
+pytestmark = pytest.mark.unit
+
+_START = "2026-01-01T00:00:00"
+_END = "2026-01-02T23:00:00"  # 2 days -> 48 hours
+
+
+def test_synthetic_weather_schema_and_shape() -> None:
+    df = synthetic_weather(FLEET, _START, _END, random_seed=1)
+    assert tuple(df.columns) == WEATHER_COLUMNS
+    assert df.height == 48 * len(FLEET)
+    assert df.null_count().to_numpy().sum() == 0
+
+
+def test_synthetic_weather_is_deterministic() -> None:
+    a = synthetic_weather(FLEET, _START, _END, random_seed=7)
+    b = synthetic_weather(FLEET, _START, _END, random_seed=7)
+    assert a.equals(b)
+
+
+def test_synthetic_ghi_zero_at_night_positive_at_noon() -> None:
+    df = synthetic_weather(FLEET, _START, _END, random_seed=1)
+    midnight = df.filter(pl.col("timestamp").dt.hour() == 0)["ghi"].to_numpy()
+    noon = df.filter(pl.col("timestamp").dt.hour() == 12)["ghi"].to_numpy()
+    assert np.all(midnight == 0.0)
+    assert noon.mean() > 0.0
+
+
+def test_get_weather_synthetic_when_use_real_false() -> None:
+    df, source = get_weather(FLEET, _START, _END, use_real=False)
+    assert source == "synthetic"
+    assert df.height == 48 * len(FLEET)
+
+
+def test_fetch_open_meteo_returns_none_on_network_error(monkeypatch) -> None:
+    def _boom(*_args, **_kwargs):
+        raise requests.RequestException
+
+    monkeypatch.setattr(weather_sources.requests, "get", _boom)
+    assert fetch_open_meteo(FLEET, _START, _END) is None
+
+
+def test_get_weather_falls_back_to_synthetic_on_failure(monkeypatch) -> None:
+    def _boom(*_args, **_kwargs):
+        raise requests.RequestException
+
+    monkeypatch.setattr(weather_sources.requests, "get", _boom)
+    df, source = get_weather(FLEET, _START, _END, use_real=True)
+    assert source == "synthetic"
+    assert df.height == 48 * len(FLEET)


### PR DESCRIPTION
## Summary

Two improvements to WAGA:

1. **Realistic, highly-variable fleet.** New `mock_data` simulation modeling **wind, solar, battery, and gas** (was wind/solar only) with real physics — turbine power curve + air-density + AR(1) turbulence, PV NOCT derate + inverter clipping, battery SOC arbitrage dispatch, gas CCGT/peaker merit-order dispatch with heat rate + CO₂.
2. **Real-time weather.** Pulls genuine hourly ERA5 data per asset site from the free [Open-Meteo archive API](https://open-meteo.com) (no key), with a physical synthetic fallback when offline.
3. **Portfolio-styled dashboard.** The static cockpit dashboard restyled to match [charleslikesdata.com](https://charleslikesdata.com) (light theme, Poppins, grayscale + pale-blue, green/gold data-viz palette) and extended with a technology-mix stacked area, battery SOC, gas CO₂, a fleet roster, and CO₂ / renewable-share KPIs.

A pure-Python **local export path** (`local_export.py` + `scripts/build_local_dashboard.py`) rebuilds the four `dashboard_exports/*.json` (schema **v2.0**) with **no Snowflake**, so the dashboard is fully reproducible on a laptop or in CI.

## Scope boundary

The Snowflake ingestion + contracted dbt marts stay **wind/solar-only** in this PR (they infer type from weather correlation). Battery/gas flow only through the local simulation → dashboard path, so the warehouse pipeline is untouched. Extending the marts to storage/thermal is a follow-up PR.

## Verification

- Annual capacity factors validated against EIA fleet averages (wind ~22–26%, solar ~19–21%, CCGT 44%, peaker 12.5%).
- `ruff` clean; `mypy` clean on new modules.
- 146 unit tests pass (43 new: physics, fleet, weather sources, simulation/export) + 21 cockpit tests.
- Dashboard rebuilt from a full year of real Open-Meteo weather and visually verified.