### PR TITLE
feat: extend Snowflake/dbt pipeline to battery + gas (unified fleet)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,8 +86,12 @@ Parquet/API sources
 - dbt staging organized into per-source subfolders (`weather/`, `generation/`)
 - New data source = new ingestion asset + staging subfolder. Pure additive.
 - dbt manifest generated at build time (`dbt parse`); code handles missing manifest gracefully
-- **Two fleets, on purpose.** The Snowflake ingestion + contracted dbt marts are **wind/solar only** (`ASSET_CONFIGS`; marts infer type from weather correlation, `accepted_values: ['wind','solar']`). The **local simulation** (`mock_data/fleet.py`) is the full **wind/solar/battery/gas** fleet and feeds the dashboard via `local_export.py` — no warehouse. Keep them independent: adding storage/thermal to the local fleet must never touch the contracted marts. Extending the Snowflake path to 4 types is a separate, warehouse-dependent change (branch marts by `asset_type`, widen `accepted_values`, add nullable type-specific columns).
-- Dashboard exports are schema-versioned (`manifest.schema_version`); the local fleet writes **v2.0** (adds battery SOC/throughput + gas fuel/heat-rate/CO₂ columns). `cockpit/data.py` tolerates missing/extra fields so both the Snowflake (v1.0) and local (v2.0) exports render.
+- **One fleet, two build paths.** The 12-asset `mock_data/fleet.FLEET` (4 wind, 4 solar, 2 battery, 2 gas) is the single source of truth. It feeds **both** the Snowflake pipeline (ingestion → RAW → dbt marts → `dashboard_export.py`) and the no-warehouse local path (`simulate.py` → `local_export.py`). Both emit the identical **v2.0** export schema.
+- **Explicit `asset_type`, not inferred.** RAW/staging/marts carry an explicit `asset_type` column (`accepted_values: ['wind','solar','battery','gas']`); the weather mart's `inferred_asset_type` is now that explicit value, not a wind-vs-solar correlation guess.
+- **Type-branched scoring** (`mart_asset_weather_performance`): weather-adjusted ratio for wind/solar, realized round-trip efficiency (discharge/charge) for battery, heat-rate efficiency (best/realized) for gas.
+- **Battery is a net load.** A charging battery has negative `net_generation_mwh` and capacity factor. Non-negativity range tests (RAW source, staging, daily mart) and the `waga_generation_value_range_check` are all scoped `where asset_type <> 'battery'`.
+- **Ingestion is deterministic per partition** (`_partition_seed(partition_key)`), so re-runs merge idempotently and the weather/generation assets stay mutually consistent. Ingestion weather is synthetic; the live Open-Meteo pull is a local-dashboard feature.
+- `cockpit/data.py` tolerates missing/extra fields, and the manifest carries `weather_source` (`open-meteo` / `synthetic` / `snowflake`) driving the dashboard's data-source badge.
 - Ingestion assets use `op_tags={"dagster/concurrency_key": "waga_ingestion"}` to prevent concurrent merges
 
 ## Key Design Decisions

--- a/README.md
+++ b/README.md
@@ -156,10 +156,12 @@ The four `dashboard_exports/*.json` files (schema v2.0) carry per-technology
 metrics — battery SOC/throughput, gas fuel/heat-rate/CO₂ — alongside the shared
 generation/capacity-factor columns.
 
-> **Scope note:** the mixed fleet is the *local dashboard* dataset. The Snowflake
-> ingestion + contracted dbt marts remain wind/solar-only (they infer asset type
-> from weather correlation); extending those marts to storage/thermal is a
-> separate, warehouse-dependent change.
+> **One fleet, both paths.** The same 12-asset fleet flows through the Snowflake
+> pipeline too: ingestion emits an explicit `asset_type` plus battery/gas
+> columns, the dbt marts branch scoring by technology (weather-adjusted for
+> wind/solar, realized round-trip efficiency for battery, heat-rate efficiency
+> for gas), and the export produces the identical v2.0 schema. The local path is
+> the no-warehouse way to build the same dashboard.
 
 ---
 

--- a/dbt/renewable_dbt/models/intermediate/int_asset_weather_join.sql
+++ b/dbt/renewable_dbt/models/intermediate/int_asset_weather_join.sql
@@ -20,12 +20,16 @@ generation_data AS (
     SELECT
         timestamp,
         asset_id,
+        asset_type,
         gross_generation_mwh,
         net_generation_mwh,
         curtailment_mwh,
         availability_pct,
         asset_capacity_mw,
         capacity_factor,
+        charge_mwh,
+        discharge_mwh,
+        heat_rate_btu_kwh,
         is_data_valid
     FROM {{ ref('stg_generation') }}
 ),
@@ -34,6 +38,7 @@ joined AS (
     SELECT
         g.timestamp,
         g.asset_id,
+        g.asset_type,
 
         -- Generation metrics
         g.gross_generation_mwh,
@@ -42,6 +47,9 @@ joined AS (
         g.availability_pct,
         g.asset_capacity_mw,
         g.capacity_factor,
+        g.charge_mwh,
+        g.discharge_mwh,
+        g.heat_rate_btu_kwh,
 
         -- Weather conditions
         w.wind_speed_mps,

--- a/dbt/renewable_dbt/models/intermediate/int_generation_daily.sql
+++ b/dbt/renewable_dbt/models/intermediate/int_generation_daily.sql
@@ -10,6 +10,7 @@ WITH daily_generation AS (
         date,
 
         -- Asset characteristics
+        MAX(asset_type) AS asset_type,
         MAX(asset_capacity_mw) AS asset_capacity_mw,
         MAX(asset_size_category) AS asset_size_category,
 
@@ -17,6 +18,14 @@ WITH daily_generation AS (
         ROUND(SUM(gross_generation_mwh), 4) AS total_gross_generation_mwh,
         ROUND(SUM(net_generation_mwh), 4) AS total_net_generation_mwh,
         ROUND(SUM(curtailment_mwh), 4) AS total_curtailment_mwh,
+
+        -- Technology-specific daily aggregates (null where not applicable)
+        ROUND(AVG(soc_pct), 2) AS avg_soc_pct,
+        ROUND(SUM(charge_mwh), 4) AS total_charge_mwh,
+        ROUND(SUM(discharge_mwh), 4) AS total_discharge_mwh,
+        ROUND(SUM(fuel_mmbtu), 4) AS total_fuel_mmbtu,
+        ROUND(AVG(heat_rate_btu_kwh), 2) AS avg_heat_rate_btu_kwh,
+        ROUND(SUM(co2_tonnes), 4) AS total_co2_tonnes,
 
         ROUND(AVG(gross_generation_mwh), 4) AS avg_hourly_gross_mwh,
         ROUND(AVG(net_generation_mwh), 4) AS avg_hourly_net_mwh,

--- a/dbt/renewable_dbt/models/marts/mart_asset_performance_daily.sql
+++ b/dbt/renewable_dbt/models/marts/mart_asset_performance_daily.sql
@@ -19,6 +19,7 @@ asset_daily_performance AS (
         g.date,
 
         -- Asset info
+        g.asset_type,
         g.asset_capacity_mw,
         g.asset_size_category,
 
@@ -28,6 +29,14 @@ asset_daily_performance AS (
         g.total_curtailment_mwh,
         g.avg_hourly_net_mwh,
         g.peak_hourly_net_mwh,
+
+        -- Technology-specific metrics (null where not applicable)
+        g.avg_soc_pct,
+        g.total_charge_mwh,
+        g.total_discharge_mwh,
+        g.total_fuel_mmbtu,
+        g.avg_heat_rate_btu_kwh,
+        g.total_co2_tonnes,
 
         -- Capacity factor
         g.daily_capacity_factor,

--- a/dbt/renewable_dbt/models/marts/mart_asset_weather_performance.sql
+++ b/dbt/renewable_dbt/models/marts/mart_asset_weather_performance.sql
@@ -5,272 +5,254 @@
     )
 }}
 
+-- Weather-adjusted performance for weather-driven assets (wind, solar), plus
+-- technology-appropriate scores for storage (battery) and thermal (gas):
+--   * wind / solar : actual vs. weather-regression-expected generation
+--   * battery      : realized round-trip efficiency (discharge / charge)
+--   * gas          : heat-rate efficiency (best / realized heat rate)
+-- ``inferred_asset_type`` is now the explicit ``asset_type`` carried from RAW,
+-- not an inference from correlation strength.
+
 WITH hourly_data AS (
     SELECT
         asset_id,
+        asset_type,
         date,
         wind_speed_mps,
         ghi,
         net_generation_mwh,
         capacity_factor,
-        asset_capacity_mw
+        asset_capacity_mw,
+        charge_mwh,
+        discharge_mwh,
+        heat_rate_btu_kwh
     FROM {{ ref('int_asset_weather_join') }}
     WHERE is_complete_record = TRUE
 ),
 
--- Calculate rolling correlations for each asset
+-- Per-asset correlations + regression models (meaningful for wind/solar).
 asset_correlations AS (
     SELECT
         asset_id,
-        
-        -- Asset characteristics
+        MAX(asset_type) AS asset_type,
         MAX(asset_capacity_mw) AS asset_capacity_mw,
-        
-        -- Overall statistics
         COUNT(*) AS total_observations,
         ROUND(AVG(net_generation_mwh), 4) AS avg_net_generation_mwh,
         ROUND(AVG(capacity_factor), 4) AS avg_capacity_factor,
         ROUND(AVG(wind_speed_mps), 2) AS avg_wind_speed_mps,
         ROUND(AVG(ghi), 2) AS avg_ghi,
-        
-        -- Correlation calculations
+
         ROUND(CORR(wind_speed_mps, net_generation_mwh), 4) AS wind_generation_correlation,
         ROUND(CORR(ghi, net_generation_mwh), 4) AS solar_generation_correlation,
         ROUND(CORR(wind_speed_mps, capacity_factor), 4) AS wind_cf_correlation,
         ROUND(CORR(ghi, capacity_factor), 4) AS solar_cf_correlation,
-        
-        -- Regression coefficients (simple linear model)
+
         ROUND(REGR_SLOPE(net_generation_mwh, wind_speed_mps), 6) AS wind_regression_slope,
         ROUND(REGR_INTERCEPT(net_generation_mwh, wind_speed_mps), 6) AS wind_regression_intercept,
         ROUND(REGR_SLOPE(net_generation_mwh, ghi), 6) AS solar_regression_slope,
         ROUND(REGR_INTERCEPT(net_generation_mwh, ghi), 6) AS solar_regression_intercept,
-        
-        -- R-squared approximation
+
         ROUND(POWER(CORR(wind_speed_mps, net_generation_mwh), 2), 4) AS wind_r_squared,
         ROUND(POWER(CORR(ghi, net_generation_mwh), 2), 4) AS solar_r_squared
-        
+
     FROM hourly_data
     GROUP BY asset_id
 ),
 
--- Calculate daily statistics for trending
+-- Daily statistics for rolling trends.
 daily_stats AS (
     SELECT
         asset_id,
         date,
-        
         COUNT(*) AS hourly_observations,
         ROUND(AVG(net_generation_mwh), 4) AS daily_avg_net_generation_mwh,
         ROUND(SUM(net_generation_mwh), 4) AS daily_total_net_generation_mwh,
-        ROUND(AVG(capacity_factor), 4) AS daily_avg_capacity_factor,
-        ROUND(AVG(wind_speed_mps), 2) AS daily_avg_wind_speed_mps,
-        ROUND(AVG(ghi), 2) AS daily_avg_ghi
-        
+        ROUND(AVG(capacity_factor), 4) AS daily_avg_capacity_factor
     FROM hourly_data
     GROUP BY asset_id, date
 ),
 
--- Calculate 7-day and 30-day rolling correlations
 rolling_correlations AS (
     SELECT
         asset_id,
         date,
-        
-        -- 7-day rolling averages
         ROUND(
             AVG(daily_avg_net_generation_mwh) OVER (
-                PARTITION BY asset_id
-                ORDER BY date
+                PARTITION BY asset_id ORDER BY date
                 ROWS BETWEEN 6 PRECEDING AND CURRENT ROW
-            ),
-            4
+            ), 4
         ) AS rolling_7d_avg_generation,
-        
         ROUND(
             AVG(daily_avg_capacity_factor) OVER (
-                PARTITION BY asset_id
-                ORDER BY date
+                PARTITION BY asset_id ORDER BY date
                 ROWS BETWEEN 6 PRECEDING AND CURRENT ROW
-            ),
-            4
+            ), 4
         ) AS rolling_7d_avg_cf,
-        
-        -- 30-day rolling averages
         ROUND(
             AVG(daily_avg_net_generation_mwh) OVER (
-                PARTITION BY asset_id
-                ORDER BY date
+                PARTITION BY asset_id ORDER BY date
                 ROWS BETWEEN 29 PRECEDING AND CURRENT ROW
-            ),
-            4
+            ), 4
         ) AS rolling_30d_avg_generation,
-        
         ROUND(
             AVG(daily_avg_capacity_factor) OVER (
-                PARTITION BY asset_id
-                ORDER BY date
+                PARTITION BY asset_id ORDER BY date
                 ROWS BETWEEN 29 PRECEDING AND CURRENT ROW
-            ),
-            4
+            ), 4
         ) AS rolling_30d_avg_cf
-        
     FROM daily_stats
 ),
 
--- Calculate expected generation using regression models
+-- Weather-regression expected generation, per hour (wind/solar).
 expected_generation AS (
     SELECT
         h.asset_id,
         h.date,
-        h.wind_speed_mps,
-        h.ghi,
         h.net_generation_mwh AS actual_generation_mwh,
-        h.capacity_factor AS actual_capacity_factor,
-        
-        -- Expected generation from wind
         ROUND(
             GREATEST(
-                c.wind_regression_intercept + (c.wind_regression_slope * h.wind_speed_mps),
-                0
-            ),
-            4
+                c.wind_regression_intercept + (c.wind_regression_slope * h.wind_speed_mps), 0
+            ), 4
         ) AS expected_generation_from_wind,
-        
-        -- Expected generation from solar
         ROUND(
             GREATEST(
-                c.solar_regression_intercept + (c.solar_regression_slope * h.ghi),
-                0
-            ),
-            4
+                c.solar_regression_intercept + (c.solar_regression_slope * h.ghi), 0
+            ), 4
         ) AS expected_generation_from_solar,
-        
         c.wind_generation_correlation,
-        c.solar_generation_correlation,
-        c.wind_r_squared,
-        c.solar_r_squared
-        
+        c.solar_generation_correlation
     FROM hourly_data h
-    INNER JOIN asset_correlations c
-        ON h.asset_id = c.asset_id
+    INNER JOIN asset_correlations c ON h.asset_id = c.asset_id
 ),
 
--- Calculate performance scores
 performance_scores AS (
     SELECT
         asset_id,
         date,
-        
-        -- Choose expected generation based on stronger correlation
         CASE
             WHEN ABS(wind_generation_correlation) > ABS(solar_generation_correlation)
             THEN expected_generation_from_wind
             ELSE expected_generation_from_solar
         END AS expected_generation_mwh,
-        
         actual_generation_mwh,
-        
-        -- Performance ratio
         ROUND(
             actual_generation_mwh / NULLIF(
                 CASE
                     WHEN ABS(wind_generation_correlation) > ABS(solar_generation_correlation)
                     THEN expected_generation_from_wind
                     ELSE expected_generation_from_solar
-                END,
-                0
-            ) * 100,
-            2
-        ) AS performance_ratio_pct,
-        
-        wind_generation_correlation,
-        solar_generation_correlation
-        
+                END, 0
+            ) * 100, 2
+        ) AS performance_ratio_pct
     FROM expected_generation
 ),
 
--- Aggregate to daily level with scores
-daily_performance_scores AS (
+-- Wind/solar daily weather-adjusted aggregates.
+daily_ws_scores AS (
     SELECT
         asset_id,
         date,
-        
         ROUND(AVG(expected_generation_mwh), 4) AS avg_expected_generation_mwh,
         ROUND(AVG(actual_generation_mwh), 4) AS avg_actual_generation_mwh,
-        ROUND(AVG(performance_ratio_pct), 2) AS avg_performance_ratio_pct,
-        
-        -- Performance score (0-100)
-        ROUND(
-            LEAST(
-                GREATEST(AVG(performance_ratio_pct), 0),
-                100
-            ),
-            2
-        ) AS performance_score,
-        
-        CASE
-            WHEN AVG(performance_ratio_pct) >= 95 THEN 'Excellent'
-            WHEN AVG(performance_ratio_pct) >= 85 THEN 'Good'
-            WHEN AVG(performance_ratio_pct) >= 70 THEN 'Fair'
-            ELSE 'Poor'
-        END AS performance_category
-        
+        ROUND(AVG(performance_ratio_pct), 2) AS avg_performance_ratio_pct
     FROM performance_scores
     GROUP BY asset_id, date
 ),
 
--- Final mart combining all metrics
+-- Technology-specific daily metrics for battery/gas scoring.
+daily_tech AS (
+    SELECT
+        asset_id,
+        date,
+        SUM(charge_mwh) AS total_charge_mwh,
+        SUM(discharge_mwh) AS total_discharge_mwh,
+        MIN(heat_rate_btu_kwh) AS min_heat_rate,
+        AVG(heat_rate_btu_kwh) AS avg_heat_rate
+    FROM hourly_data
+    GROUP BY asset_id, date
+),
+
+-- Combine into a single daily score, branched by technology.
+daily_performance_scores AS (
+    SELECT
+        ac.asset_id,
+        ws.date,
+        ac.asset_type,
+        ws.avg_expected_generation_mwh,
+        ws.avg_actual_generation_mwh,
+        ws.avg_performance_ratio_pct,
+        ROUND(
+            CASE ac.asset_type
+                WHEN 'battery' THEN COALESCE(
+                    LEAST(GREATEST(
+                        dt.total_discharge_mwh / NULLIF(dt.total_charge_mwh, 0) * 100, 0
+                    ), 100), 100
+                )
+                WHEN 'gas' THEN COALESCE(
+                    LEAST(GREATEST(
+                        dt.min_heat_rate / NULLIF(dt.avg_heat_rate, 0) * 100, 0
+                    ), 100), 100
+                )
+                ELSE COALESCE(LEAST(GREATEST(ws.avg_performance_ratio_pct, 0), 100), 0)
+            END, 2
+        ) AS performance_score
+    FROM asset_correlations ac
+    INNER JOIN daily_ws_scores ws ON ac.asset_id = ws.asset_id
+    LEFT JOIN daily_tech dt
+        ON ws.asset_id = dt.asset_id AND ws.date = dt.date
+),
+
 final_mart AS (
     SELECT
         ac.asset_id,
         ps.date,
-        
+
         -- Asset characteristics
         ac.asset_capacity_mw,
-        
-        -- Overall correlations
+
+        -- Overall correlations (meaningful for wind/solar)
         ac.wind_generation_correlation,
         ac.solar_generation_correlation,
         ac.wind_cf_correlation,
         ac.solar_cf_correlation,
         ac.wind_r_squared,
         ac.solar_r_squared,
-        
+
         -- Regression parameters
         ac.wind_regression_slope,
         ac.wind_regression_intercept,
         ac.solar_regression_slope,
         ac.solar_regression_intercept,
-        
+
         -- Daily performance
         ps.avg_expected_generation_mwh,
         ps.avg_actual_generation_mwh,
         ps.avg_performance_ratio_pct,
         ps.performance_score,
-        ps.performance_category,
-        
+        CASE
+            WHEN ps.performance_score >= 95 THEN 'Excellent'
+            WHEN ps.performance_score >= 85 THEN 'Good'
+            WHEN ps.performance_score >= 70 THEN 'Fair'
+            ELSE 'Poor'
+        END AS performance_category,
+
         -- Rolling metrics
         rc.rolling_7d_avg_generation,
         rc.rolling_7d_avg_cf,
         rc.rolling_30d_avg_generation,
         rc.rolling_30d_avg_cf,
-        
-        -- Asset type inference (based on stronger correlation)
-        CASE
-            WHEN ABS(ac.wind_generation_correlation) > ABS(ac.solar_generation_correlation)
-            THEN 'wind'
-            ELSE 'solar'
-        END AS inferred_asset_type,
-        
+
+        -- Explicit technology (carried from RAW, not inferred)
+        ac.asset_type AS inferred_asset_type,
+
         -- Data quality
         ac.total_observations AS total_hourly_observations
-        
+
     FROM asset_correlations ac
     INNER JOIN daily_performance_scores ps
         ON ac.asset_id = ps.asset_id
     LEFT JOIN rolling_correlations rc
-        ON ac.asset_id = rc.asset_id
-        AND ps.date = rc.date
+        ON ac.asset_id = rc.asset_id AND ps.date = rc.date
 )
 
 SELECT * FROM final_mart

--- a/dbt/renewable_dbt/models/marts/marts.yml
+++ b/dbt/renewable_dbt/models/marts/marts.yml
@@ -23,6 +23,16 @@ models:
         tests:
           - not_null
 
+      - name: asset_type
+        data_type: varchar
+        description: "Technology: wind, solar, battery, or gas"
+        constraints:
+          - type: not_null
+        tests:
+          - not_null
+          - accepted_values:
+              values: ['wind', 'solar', 'battery', 'gas']
+
       - name: asset_capacity_mw
         data_type: float
         description: "Asset nameplate capacity in MW"
@@ -55,16 +65,44 @@ models:
         data_type: float
         description: "Peak hourly net generation"
 
+      - name: avg_soc_pct
+        data_type: float
+        description: "Battery average daily state of charge (%); null for non-storage"
+
+      - name: total_charge_mwh
+        data_type: float
+        description: "Battery total daily charge energy (MWh); null for non-storage"
+
+      - name: total_discharge_mwh
+        data_type: float
+        description: "Battery total daily discharge energy (MWh); null for non-storage"
+
+      - name: total_fuel_mmbtu
+        data_type: float
+        description: "Gas total daily fuel burn (MMBtu); null for non-thermal"
+
+      - name: avg_heat_rate_btu_kwh
+        data_type: float
+        description: "Gas average daily heat rate (Btu/kWh); null for non-thermal"
+
+      - name: total_co2_tonnes
+        data_type: float
+        description: "Gas total daily CO2 emissions (tonnes); null for non-thermal"
+
       - name: daily_capacity_factor
         data_type: float
-        description: "Daily capacity factor"
+        description: "Daily capacity factor (negative for a charging battery)"
         constraints:
           - type: not_null
         tests:
           - not_null
+          # A charging battery has a negative daily CF; the 0-1.1 band applies
+          # only to the generating technologies.
           - dbt_utils.accepted_range:
               min_value: 0
               max_value: 1.1
+              config:
+                where: "asset_type <> 'battery'"
 
       - name: avg_hourly_capacity_factor
         data_type: float
@@ -311,13 +349,13 @@ models:
 
       - name: inferred_asset_type
         data_type: varchar
-        description: "Inferred asset type based on weather correlations"
+        description: "Explicit asset technology carried from RAW (wind/solar/battery/gas)"
         constraints:
           - type: not_null
         tests:
           - not_null
           - accepted_values:
-              values: ['wind', 'solar']
+              values: ['wind', 'solar', 'battery', 'gas']
 
       - name: total_hourly_observations
         data_type: number

--- a/dbt/renewable_dbt/models/staging/generation/_generation__models.yml
+++ b/dbt/renewable_dbt/models/staging/generation/_generation__models.yml
@@ -14,8 +14,15 @@ models:
         tests:
           - not_null
 
+      - name: asset_type
+        description: "Technology: wind, solar, battery, or gas"
+        tests:
+          - not_null
+          - accepted_values:
+              values: ['wind', 'solar', 'battery', 'gas']
+
       - name: net_generation_mwh
-        description: "Net generation in MWh"
+        description: "Net generation in MWh (negative for a charging battery)"
         tests:
           - not_null
 
@@ -23,10 +30,14 @@ models:
         description: "Capacity factor (net generation / capacity)"
         tests:
           - not_null
+          # A charging battery has a negative capacity factor; the 0-1.1 band
+          # only applies to the generating technologies.
           - dbt_utils.accepted_range:
               min_value: 0
               max_value: 1.1
               inclusive: true
+              config:
+                where: "asset_type <> 'battery'"
 
       - name: is_data_valid
         description: "Flag indicating data passes validation rules"

--- a/dbt/renewable_dbt/models/staging/generation/_generation__sources.yml
+++ b/dbt/renewable_dbt/models/staging/generation/_generation__sources.yml
@@ -19,8 +19,15 @@ sources:
             tests:
               - not_null
 
+          - name: asset_type
+            description: "Technology: wind, solar, battery, or gas"
+            tests:
+              - not_null
+              - accepted_values:
+                  values: ['wind', 'solar', 'battery', 'gas']
+
           - name: gross_generation_mwh
-            description: "Gross generation in MWh (before losses)"
+            description: "Gross generation in MWh (before losses); battery = discharge"
             tests:
               - not_null
               - dbt_utils.accepted_range:
@@ -28,12 +35,34 @@ sources:
                   inclusive: true
 
           - name: net_generation_mwh
-            description: "Net generation in MWh (after losses)"
+            description: "Net generation in MWh (after losses); negative for a charging battery"
             tests:
               - not_null
+              # A charging battery is a net load (negative). Non-negativity only
+              # holds for the generating technologies.
               - dbt_utils.accepted_range:
                   min_value: 0
                   inclusive: true
+                  config:
+                    where: "asset_type <> 'battery'"
+
+          - name: soc_pct
+            description: "Battery state of charge (%); null for non-storage"
+
+          - name: charge_mwh
+            description: "Battery energy charged this hour (MWh); null for non-storage"
+
+          - name: discharge_mwh
+            description: "Battery energy discharged this hour (MWh); null for non-storage"
+
+          - name: fuel_mmbtu
+            description: "Gas fuel burned this hour (MMBtu); null for non-thermal"
+
+          - name: heat_rate_btu_kwh
+            description: "Gas heat rate (Btu/kWh); null for non-thermal"
+
+          - name: co2_tonnes
+            description: "Gas CO2 emissions this hour (tonnes); null for non-thermal"
 
           - name: curtailment_mwh
             description: "Curtailed energy in MWh"

--- a/dbt/renewable_dbt/models/staging/generation/stg_generation.sql
+++ b/dbt/renewable_dbt/models/staging/generation/stg_generation.sql
@@ -9,11 +9,18 @@ WITH source_data AS (
     SELECT
         timestamp,
         asset_id,
+        asset_type,
         gross_generation_mwh,
         net_generation_mwh,
         curtailment_mwh,
         availability_pct,
         asset_capacity_mw,
+        soc_pct,
+        charge_mwh,
+        discharge_mwh,
+        fuel_mmbtu,
+        heat_rate_btu_kwh,
+        co2_tonnes,
         _dlt_load_id
     FROM {{ source('waga_raw', 'generation') }}
 ),
@@ -30,6 +37,7 @@ transformed AS (
         -- Primary keys
         timestamp::TIMESTAMP_NTZ AS timestamp,
         asset_id::VARCHAR AS asset_id,
+        asset_type::VARCHAR AS asset_type,
 
         -- Generation measurements
         ROUND(gross_generation_mwh::FLOAT, 4) AS gross_generation_mwh,
@@ -37,6 +45,14 @@ transformed AS (
         ROUND(curtailment_mwh::FLOAT, 4) AS curtailment_mwh,
         ROUND(availability_pct::FLOAT, 2) AS availability_pct,
         ROUND(asset_capacity_mw::FLOAT, 2) AS asset_capacity_mw,
+
+        -- Technology-specific measurements (null where not applicable)
+        ROUND(soc_pct::FLOAT, 2) AS soc_pct,
+        ROUND(charge_mwh::FLOAT, 4) AS charge_mwh,
+        ROUND(discharge_mwh::FLOAT, 4) AS discharge_mwh,
+        ROUND(fuel_mmbtu::FLOAT, 4) AS fuel_mmbtu,
+        ROUND(heat_rate_btu_kwh::FLOAT, 2) AS heat_rate_btu_kwh,
+        ROUND(co2_tonnes::FLOAT, 4) AS co2_tonnes,
 
         -- Derived time features
         EXTRACT(HOUR FROM timestamp) AS hour_of_day,
@@ -97,8 +113,13 @@ transformed AS (
             ELSE TRUE
         END AS is_data_valid,
 
+        -- Only weather-driven assets are expected to always produce when up;
+        -- idle battery/gas hours are normal dispatch, not anomalies.
         CASE
-            WHEN net_generation_mwh = 0 AND availability_pct > 0 THEN TRUE
+            WHEN net_generation_mwh = 0
+                AND availability_pct > 0
+                AND asset_type IN ('wind', 'solar')
+            THEN TRUE
             ELSE FALSE
         END AS is_zero_generation_anomaly
 

--- a/src/weather_analytics/assets/analytics/dashboard_export.py
+++ b/src/weather_analytics/assets/analytics/dashboard_export.py
@@ -32,11 +32,12 @@ _MIN_ROWS = 10
 _SOURCE_MART = "WAGA.MARTS.mart_asset_performance_daily"
 _WEATHER_MART = "WAGA.MARTS.mart_asset_weather_performance"
 _EXPORT_DIR = Path("dashboard_exports")
-_SCHEMA_VERSION = "1.0"
+_SCHEMA_VERSION = "2.0"
 
 _DAILY_PERFORMANCE_COLUMNS: tuple[str, ...] = (
     "asset_id",
     "date",
+    "asset_type",
     "total_net_generation_mwh",
     "daily_capacity_factor",
     "avg_availability_pct",
@@ -50,6 +51,13 @@ _DAILY_PERFORMANCE_COLUMNS: tuple[str, ...] = (
     "avg_ghi",
     "avg_temperature_c",
     "data_completeness_pct",
+    # Technology-specific (null where not applicable).
+    "avg_soc_pct",
+    "total_charge_mwh",
+    "total_discharge_mwh",
+    "total_fuel_mmbtu",
+    "avg_heat_rate_btu_kwh",
+    "total_co2_tonnes",
 )
 
 _WEATHER_PERFORMANCE_COLUMNS: tuple[str, ...] = (
@@ -67,14 +75,14 @@ _WEATHER_PERFORMANCE_COLUMNS: tuple[str, ...] = (
     "rolling_30d_avg_cf",
 )
 
-# Mart column names for the asset dimension.
-# ``asset_capacity_mw`` and ``asset_size_category`` come from
-# ``mart_asset_performance_daily``; ``inferred_asset_type`` comes from
-# ``mart_asset_weather_performance``.  They are joined and renamed to the
-# data-contract names (``capacity_mw``, ``size_category``, ``asset_type``)
-# during assets_df construction below.
+# Mart column names for the asset dimension. ``asset_type``,
+# ``asset_capacity_mw`` and ``asset_size_category`` all come from
+# ``mart_asset_performance_daily`` and are renamed to the data-contract names
+# (``asset_type``, ``capacity_mw``, ``size_category``) during assets_df
+# construction below.
 _DAILY_ASSET_DIM_COLUMNS: tuple[str, ...] = (
     "asset_id",
+    "asset_type",
     "asset_capacity_mw",
     "asset_size_category",
 )
@@ -199,34 +207,35 @@ def waga_dashboard_export_build(
         weather_df = raw_weather.select(list(_WEATHER_PERFORMANCE_COLUMNS))
 
         # --- Build assets dimension ---
-        # ``asset_capacity_mw`` and ``asset_size_category`` are in the daily
-        # mart; ``inferred_asset_type`` is in the weather mart (it is a model
-        # inference, not a generation concept).  Join on asset_id then rename
-        # to the data-contract column names.
-        daily_dim = raw_daily.select(list(_DAILY_ASSET_DIM_COLUMNS)).unique()
-        weather_type = raw_weather.select(["asset_id", "inferred_asset_type"]).unique(
+        # ``asset_type``, ``asset_capacity_mw`` and ``asset_size_category`` are
+        # all in the daily mart (asset_type is now explicit, carried from RAW).
+        # Project, compute a display name, and rename to the data-contract names.
+        daily_dim = raw_daily.select(list(_DAILY_ASSET_DIM_COLUMNS)).unique(
             subset=["asset_id"]
         )
         asset_id_suffix = pl.col("asset_id").str.split("_").list.last()
         display_name_expr = (
-            pl.col("inferred_asset_type").str.to_titlecase()
+            pl.col("asset_type").str.to_titlecase()
             + pl.lit(" Asset ")
             + asset_id_suffix
             + pl.lit(" (")
             + pl.col("asset_capacity_mw").cast(pl.Int64).cast(pl.Utf8)
             + pl.lit(" MW)")
         )
-        assets_df = (
-            daily_dim.join(weather_type, on="asset_id", how="left")
-            .with_columns(display_name_expr.alias("display_name"))
-            .rename(
-                {
-                    "inferred_asset_type": "asset_type",
-                    "asset_capacity_mw": "capacity_mw",
-                    "asset_size_category": "size_category",
-                }
-            )
+        assets_df = daily_dim.with_columns(
+            display_name_expr.alias("display_name")
+        ).rename(
+            {
+                "asset_capacity_mw": "capacity_mw",
+                "asset_size_category": "size_category",
+            }
         )
+        asset_type_counts = {
+            str(row["asset_type"]): int(row["count"])
+            for row in assets_df.group_by("asset_type").len(name="count").iter_rows(
+                named=True
+            )
+        }
 
         # --- Build manifest ---
         try:
@@ -243,6 +252,8 @@ def waga_dashboard_export_build(
                 "end": str(daily_df["date"].max()),
             },
             "asset_count": int(assets_df.shape[0]),
+            "asset_type_counts": asset_type_counts,
+            "weather_source": "snowflake",
             "row_counts": {
                 "daily_performance": daily_df.shape[0],
                 "weather_performance": weather_df.shape[0],

--- a/src/weather_analytics/assets/ingestion/generation.py
+++ b/src/weather_analytics/assets/ingestion/generation.py
@@ -1,7 +1,7 @@
 """Generation ingestion asset — generates mock data into Snowflake RAW."""
 
-import time
 from collections.abc import Iterator
+from datetime import date
 
 import dlt
 from dagster import (
@@ -19,6 +19,12 @@ from weather_analytics.mock_data.generate_generation import (
 from weather_analytics.resources.dlt_resource import DltIngestionResource
 
 GENERATION_PARTITIONS = DailyPartitionsDefinition(start_date="2023-01-01")
+
+
+def _partition_seed(partition_key: str) -> int:
+    """Deterministic per-day seed so re-runs merge idempotently and weather and
+    generation ingestion stay mutually consistent for the same partition."""
+    return date.fromisoformat(partition_key).toordinal()
 
 
 @dlt.resource(
@@ -84,7 +90,7 @@ def waga_generation_ingestion(
     df = generate_generation_data(
         start_date=start,
         end_date=end,
-        random_seed=int(time.time()),
+        random_seed=_partition_seed(partition_key),
     )
     row_count = len(df)
     asset_count = len(ASSET_CONFIGS)

--- a/src/weather_analytics/assets/ingestion/weather.py
+++ b/src/weather_analytics/assets/ingestion/weather.py
@@ -1,7 +1,7 @@
 """Weather ingestion asset — generates mock data into Snowflake RAW."""
 
-import time
 from collections.abc import Iterator
+from datetime import date
 
 import dlt
 from dagster import (
@@ -21,6 +21,12 @@ WEATHER_PARTITIONS = DailyPartitionsDefinition(start_date="2023-01-01")
 # Must match len(ASSET_CONFIGS) so weather and generation assets
 # produce data for the same set of assets.
 WEATHER_ASSET_COUNT = len(ASSET_CONFIGS)
+
+
+def _partition_seed(partition_key: str) -> int:
+    """Deterministic per-day seed (matches the generation asset) so weather and
+    generation ingestion stay mutually consistent for the same partition."""
+    return date.fromisoformat(partition_key).toordinal()
 
 
 @dlt.resource(
@@ -87,7 +93,7 @@ def waga_weather_ingestion(
         start_date=start,
         end_date=end,
         asset_count=WEATHER_ASSET_COUNT,
-        random_seed=int(time.time()),
+        random_seed=_partition_seed(partition_key),
     )
     row_count = len(df)
 

--- a/src/weather_analytics/checks/data_quality.py
+++ b/src/weather_analytics/checks/data_quality.py
@@ -220,8 +220,8 @@ def waga_weather_value_range_check(
             f"""
             SELECT COUNT(*) AS violations
             FROM WAGA.STAGING.stg_weather
-            WHERE wind_speed < {WIND_SPEED_MIN}
-               OR wind_speed > {WIND_SPEED_MAX}
+            WHERE wind_speed_mps < {WIND_SPEED_MIN}
+               OR wind_speed_mps > {WIND_SPEED_MAX}
                OR temperature_c < {TEMPERATURE_C_MIN}
                OR temperature_c > {TEMPERATURE_C_MAX}
                OR relative_humidity < {RELATIVE_HUMIDITY_MIN}
@@ -246,7 +246,9 @@ def waga_generation_value_range_check(
 ) -> AssetCheckResult:
     """Validate physical plausibility of generation columns.
 
-    Checks generation_mwh >= 0 and capacity_factor in [0, 1].
+    Checks net_generation_mwh >= 0 and capacity_factor in [0, 1] for the
+    generating technologies. A charging battery is a net load (negative net
+    generation and capacity factor), so storage is excluded from these bounds.
     """
     conn = snowflake.get_connection()
     try:
@@ -255,9 +257,12 @@ def waga_generation_value_range_check(
             f"""
             SELECT COUNT(*) AS violations
             FROM WAGA.STAGING.stg_generation
-            WHERE generation_mwh < {GENERATION_MWH_MIN}
-               OR capacity_factor < {CAPACITY_FACTOR_MIN}
-               OR capacity_factor > {CAPACITY_FACTOR_MAX}
+            WHERE asset_type <> 'battery'
+              AND (
+                net_generation_mwh < {GENERATION_MWH_MIN}
+                OR capacity_factor < {CAPACITY_FACTOR_MIN}
+                OR capacity_factor > {CAPACITY_FACTOR_MAX}
+              )
             """
         )
         violations: int = cursor.fetchone()[0]

--- a/src/weather_analytics/mock_data/generate_generation.py
+++ b/src/weather_analytics/mock_data/generate_generation.py
@@ -1,227 +1,80 @@
-"""Generate mock generation data for renewable energy assets.
+"""Generate mock generation data for the renewable + thermal fleet.
 
-Produces realistic hourly generation records with wind power curves,
-solar PV output, curtailment, and availability patterns.
+Thin wrapper over the physics-based fleet simulation
+(:func:`weather_analytics.mock_data.simulate.simulate_fleet`). Produces hourly
+records for every asset in :data:`weather_analytics.mock_data.fleet.FLEET` —
+wind, solar, battery, and gas — carrying an explicit ``asset_type`` plus
+technology-specific columns (battery SOC/throughput, gas fuel/heat-rate/CO2).
+
+The Dagster ingestion asset merges these records into Snowflake RAW; dlt evolves
+the RAW schema to add the new columns. Weather here is synthetic (deterministic
+per seed) so ingestion is reproducible; the live Open-Meteo pull is a
+local-dashboard feature (see ``simulate_fleet(use_real_weather=True)``).
 """
 
 from __future__ import annotations
 
 import logging
-from datetime import datetime
 from pathlib import Path
 
-import numpy as np
 import polars as pl
+
+from weather_analytics.mock_data.fleet import FLEET
+from weather_analytics.mock_data.simulate import simulate_fleet
 
 logger = logging.getLogger(__name__)
 
+# Backward-compatible ``{asset_id: {"capacity_mw", "type"}}`` view of the fleet,
+# derived from the single source of truth in ``fleet.FLEET``.
 ASSET_CONFIGS: dict[str, dict[str, float | str]] = {
-    "ASSET_001": {"capacity_mw": 50.0, "type": "wind"},
-    "ASSET_002": {"capacity_mw": 75.0, "type": "wind"},
-    "ASSET_003": {"capacity_mw": 100.0, "type": "wind"},
-    "ASSET_004": {"capacity_mw": 45.0, "type": "wind"},
-    "ASSET_005": {"capacity_mw": 80.0, "type": "wind"},
-    "ASSET_006": {"capacity_mw": 30.0, "type": "solar"},
-    "ASSET_007": {"capacity_mw": 50.0, "type": "solar"},
-    "ASSET_008": {"capacity_mw": 40.0, "type": "solar"},
-    "ASSET_009": {"capacity_mw": 60.0, "type": "solar"},
-    "ASSET_010": {"capacity_mw": 35.0, "type": "solar"},
+    asset.asset_id: {"capacity_mw": asset.capacity_mw, "type": asset.asset_type}
+    for asset in FLEET
 }
-
-
-def _wind_power_curve(wind_speed: np.ndarray, capacity_mw: float) -> np.ndarray:
-    """Calculate wind turbine power output based on simplified power curve.
-
-    Parameters
-    ----------
-    wind_speed : np.ndarray
-        Wind speed values in m/s.
-    capacity_mw : float
-        Turbine nameplate capacity in MW.
-
-    Returns
-    -------
-    np.ndarray
-        Power output in MWh for each wind speed value.
-    """
-    power = np.zeros_like(wind_speed)
-
-    # Wind turbine characteristic speeds (m/s): cut-in, rated, cut-out
-    cut_in, rated, cut_out = 3, 12, 25
-
-    mask_ramp = (wind_speed >= cut_in) & (wind_speed < rated)
-    power[mask_ramp] = capacity_mw * ((wind_speed[mask_ramp] - cut_in) / 9) ** 3
-
-    mask_rated = (wind_speed >= rated) & (wind_speed < cut_out)
-    power[mask_rated] = capacity_mw
-
-    power[wind_speed >= cut_out] = 0
-    return power
-
-
-def _solar_power_output(ghi: np.ndarray, capacity_mw: float) -> np.ndarray:
-    """Calculate solar PV power output based on irradiance.
-
-    Parameters
-    ----------
-    ghi : np.ndarray
-        Global horizontal irradiance values in W/m^2.
-    capacity_mw : float
-        PV nameplate capacity in MW.
-
-    Returns
-    -------
-    np.ndarray
-        Power output in MWh for each irradiance value.
-    """
-    efficiency = 0.85
-    power = (ghi / 1000) * capacity_mw * efficiency
-    return np.clip(power, 0, capacity_mw)
 
 
 def generate_generation_data(
     start_date: str,
     end_date: str,
-    asset_configs: dict[str, dict[str, float | str]] | None = None,
+    asset_configs: dict[str, dict[str, float | str]] | None = None,  # noqa: ARG001
     random_seed: int = 42,
 ) -> pl.DataFrame:
-    """Generate realistic hourly generation data for renewable energy assets.
+    """Generate realistic hourly generation for the full fleet.
 
     Parameters
     ----------
-    start_date : str
-        ISO-format start datetime (inclusive).
-    end_date : str
-        ISO-format end datetime (inclusive).
-    asset_configs : dict[str, dict[str, float | str]] | None
-        Mapping of asset_id to config dict with ``capacity_mw`` and ``type``
-        keys.  Defaults to :data:`ASSET_CONFIGS`.
+    start_date, end_date : str
+        ISO-format datetimes (inclusive) at hourly resolution.
+    asset_configs : dict | None
+        Deprecated / ignored — the fleet is defined by ``fleet.FLEET``. Kept for
+        backward compatibility with earlier callers.
     random_seed : int
-        Numpy random seed for reproducibility.
+        Seed for the (synthetic) weather and all stochastic physics.
 
     Returns
     -------
     pl.DataFrame
-        Generation DataFrame with columns: ``timestamp``, ``asset_id``,
-        ``gross_generation_mwh``, ``net_generation_mwh``,
-        ``curtailment_mwh``, ``availability_pct``, ``asset_capacity_mw``.
+        Hourly generation with columns ``timestamp``, ``asset_id``,
+        ``asset_type``, ``gross_generation_mwh``, ``net_generation_mwh``
+        (negative for a charging battery), ``curtailment_mwh``,
+        ``availability_pct``, ``asset_capacity_mw`` and the nullable
+        technology-specific columns ``soc_pct``, ``charge_mwh``,
+        ``discharge_mwh``, ``fuel_mmbtu``, ``heat_rate_btu_kwh``, ``co2_tonnes``.
     """
-    if asset_configs is None:
-        asset_configs = ASSET_CONFIGS
-
     logger.info(
         "Generating generation data from %s to %s for %d assets",
         start_date,
         end_date,
-        len(asset_configs),
+        len(FLEET),
     )
-
-    rng = np.random.default_rng(random_seed)
-
-    timestamps = pl.datetime_range(
-        start=datetime.fromisoformat(start_date),
-        end=datetime.fromisoformat(end_date),
-        interval="1h",
-        eager=True,
+    result = simulate_fleet(
+        start_date, end_date, FLEET, use_real_weather=False, random_seed=random_seed
     )
-
-    asset_ids = list(asset_configs.keys())
-    base_df = pl.DataFrame({"timestamp": timestamps}).join(
-        pl.DataFrame({"asset_id": asset_ids}),
-        how="cross",
-    )
-
-    n_rows = len(base_df)
-
-    # Build synthetic weather signals for generation correlation
-    df = base_df.with_columns(
-        pl.col("timestamp").dt.hour().alias("hour"),
-        pl.col("timestamp").dt.ordinal_day().alias("day_of_year"),
-    )
-
-    hour_array = df["hour"].to_numpy()
-    day_of_year = df["day_of_year"].to_numpy()
-
-    # Synthetic wind speed
-    seasonal_wind = 10 + 3 * np.sin(2 * np.pi * day_of_year / 365)
-    diurnal_wind = 1.5 * np.sin(2 * np.pi * (hour_array - 6) / 24)
-    wind_noise = rng.normal(0, 2, n_rows)
-    wind_speed = np.clip(seasonal_wind + diurnal_wind + wind_noise, 0, 25)
-
-    # Synthetic GHI
-    max_ghi = 900 + 100 * np.sin(2 * np.pi * (day_of_year - 80) / 365)
-    solar_hour = hour_array - 12
-    daylight_half_span = 6  # hours from solar noon with nonzero GHI
-    ghi_pattern = np.where(
-        np.abs(solar_hour) < daylight_half_span,
-        max_ghi * (1 - (solar_hour / 8) ** 2),
-        0,
-    )
-    cloud_factor = rng.uniform(0.7, 1.0, n_rows)
-    ghi = np.clip(ghi_pattern * cloud_factor, 0, 1000)
-
-    # Compute gross generation per asset type
-    asset_id_list = df["asset_id"].to_list()
-    gross_generation = np.zeros(n_rows)
-    asset_capacity = np.zeros(n_rows)
-
-    for i, asset_id_val in enumerate(asset_id_list):
-        cfg = asset_configs[asset_id_val]
-        capacity = float(cfg["capacity_mw"])
-        asset_type = cfg["type"]
-        asset_capacity[i] = capacity
-
-        if asset_type == "wind":
-            gross_generation[i] = _wind_power_curve(
-                np.array([wind_speed[i]]), capacity
-            )[0]
-        else:
-            gross_generation[i] = _solar_power_output(np.array([ghi[i]]), capacity)[0]
-
-    # Performance and loss factors
-    performance_factor = rng.uniform(0.95, 1.0, n_rows)
-    gross_generation = gross_generation * performance_factor
-
-    loss_factor = rng.uniform(0.90, 0.95, n_rows)
-    net_generation = gross_generation * loss_factor
-
-    # Curtailment
-    curtailment_probability = gross_generation / (asset_capacity + 1e-6)
-    curtailment_mask = rng.random(n_rows) < (curtailment_probability * 0.1)
-    curtailment = np.where(
-        curtailment_mask,
-        rng.uniform(0.05, 0.15, n_rows) * gross_generation,
-        0,
-    )
-    net_generation = np.maximum(net_generation - curtailment, 0)
-
-    # Availability
-    base_availability = 95.0
-    availability_variation = rng.normal(0, 5, n_rows)
-    availability = np.clip(base_availability + availability_variation, 85, 100)
-
-    availability_factor = availability / 100
-    gross_generation = gross_generation * availability_factor
-    net_generation = net_generation * availability_factor
-
-    result = (
-        df.select(["timestamp", "asset_id"])
-        .with_columns(
-            pl.Series("gross_generation_mwh", gross_generation),
-            pl.Series("net_generation_mwh", net_generation),
-            pl.Series("curtailment_mwh", curtailment),
-            pl.Series("availability_pct", availability),
-            pl.Series("asset_capacity_mw", asset_capacity),
-        )
-        .sort(["timestamp", "asset_id"])
-    )
-
     logger.info(
-        "Generation data generation completed: %d rows, %d assets",
-        len(result),
-        len(asset_configs),
+        "Generation data completed: %d rows, %d assets",
+        result.generation.height,
+        len(FLEET),
     )
-    return result
+    return result.generation
 
 
 def save_generation_parquet(
@@ -251,18 +104,12 @@ def save_generation_parquet(
         dates = (
             df.select(pl.col("timestamp").dt.date().alias("date")).unique().sort("date")
         )
-        logger.info(
-            "Saving %d daily generation files to %s",
-            len(dates),
-            output_dir,
-        )
-
+        logger.info("Saving %d daily generation files to %s", len(dates), output_dir)
         for (date_val,) in dates.iter_rows():
             date_str = date_val.isoformat()
             daily_df = df.filter(pl.col("timestamp").dt.date() == date_val)
             output_path = output_dir / f"generation_{date_str}.parquet"
             daily_df.write_parquet(output_path, compression="snappy")
-
         logger.info("Saved %d generation files", len(dates))
     else:
         output_path = output_dir / "generation_all.parquet"

--- a/src/weather_analytics/mock_data/generate_weather.py
+++ b/src/weather_analytics/mock_data/generate_weather.py
@@ -1,147 +1,71 @@
-"""Generate mock weather data for renewable energy assets.
+"""Generate mock weather data for the fleet sites.
 
-Produces realistic hourly weather observations with seasonal and diurnal
-patterns for wind, solar irradiance, temperature, pressure, and humidity.
+Thin wrapper over :func:`weather_analytics.mock_data.weather_sources.synthetic_weather`,
+producing the RAW-weather schema (no ``cloud_cover_pct``) for every asset in
+:data:`weather_analytics.mock_data.fleet.FLEET`. Deterministic per seed so the
+weather and generation ingestion assets stay consistent for a given partition.
 """
 
 from __future__ import annotations
 
 import logging
-from datetime import datetime
 from pathlib import Path
 
-import numpy as np
 import polars as pl
 
+from weather_analytics.mock_data.fleet import FLEET
+from weather_analytics.mock_data.weather_sources import synthetic_weather
+
 logger = logging.getLogger(__name__)
+
+# RAW weather columns (excludes the simulation-only ``cloud_cover_pct``).
+_RAW_WEATHER_COLUMNS: tuple[str, ...] = (
+    "timestamp",
+    "asset_id",
+    "wind_speed_mps",
+    "wind_direction_deg",
+    "ghi",
+    "temperature_c",
+    "pressure_hpa",
+    "relative_humidity",
+)
 
 
 def generate_weather_data(
     start_date: str,
     end_date: str,
-    asset_count: int,
+    asset_count: int | None = None,  # noqa: ARG001
     random_seed: int = 42,
 ) -> pl.DataFrame:
-    """Generate realistic hourly weather data for multiple assets.
+    """Generate realistic hourly weather for the full fleet.
 
     Parameters
     ----------
-    start_date : str
-        ISO-format start datetime (inclusive).
-    end_date : str
-        ISO-format end datetime (inclusive).
-    asset_count : int
-        Number of simulated asset sites.
+    start_date, end_date : str
+        ISO-format datetimes (inclusive) at hourly resolution.
+    asset_count : int | None
+        Deprecated / ignored — the fleet is defined by ``fleet.FLEET``.
     random_seed : int
-        Numpy random seed for reproducibility.
+        Seed for reproducibility (must match the generation asset's seed to keep
+        weather and generation consistent for the same partition).
 
     Returns
     -------
     pl.DataFrame
-        Weather DataFrame with columns: ``timestamp``, ``asset_id``,
-        ``wind_speed_mps``, ``wind_direction_deg``, ``ghi``,
-        ``temperature_c``, ``pressure_hpa``, ``relative_humidity``.
+        Weather with columns ``timestamp``, ``asset_id``, ``wind_speed_mps``,
+        ``wind_direction_deg``, ``ghi``, ``temperature_c``, ``pressure_hpa``,
+        ``relative_humidity``.
     """
     logger.info(
         "Generating weather data from %s to %s for %d assets",
         start_date,
         end_date,
-        asset_count,
+        len(FLEET),
     )
-
-    rng = np.random.default_rng(random_seed)
-
-    timestamps = pl.datetime_range(
-        start=datetime.fromisoformat(start_date),
-        end=datetime.fromisoformat(end_date),
-        interval="1h",
-        eager=True,
-    )
-
-    asset_ids = [f"ASSET_{str(i + 1).zfill(3)}" for i in range(asset_count)]
-
-    base_df = pl.DataFrame({"timestamp": timestamps}).join(
-        pl.DataFrame({"asset_id": asset_ids}),
-        how="cross",
-    )
-
-    n_rows = len(base_df)
-
-    df = base_df.with_columns(
-        pl.col("timestamp").dt.hour().alias("hour"),
-        pl.col("timestamp").dt.month().alias("month"),
-        pl.col("timestamp").dt.ordinal_day().alias("day_of_year"),
-    )
-
-    hour_array = df["hour"].to_numpy()
-    day_of_year = df["day_of_year"].to_numpy()
-
-    # Wind speed: seasonal + diurnal + noise, clipped to [0, 25]
-    seasonal_wind = 10 + 3 * np.sin(2 * np.pi * day_of_year / 365)
-    diurnal_wind = 1.5 * np.sin(2 * np.pi * (hour_array - 6) / 24)
-    wind_noise = rng.normal(0, 2, n_rows)
-    wind_speed = np.clip(seasonal_wind + diurnal_wind + wind_noise, 0, 25)
-
-    # Wind direction: asset-specific base + noise, mod 360
-    asset_base_direction = {asset: rng.uniform(0, 360) for asset in asset_ids}
-    base_direction = np.array(
-        [asset_base_direction[a] for a in df["asset_id"].to_list()]
-    )
-    direction_change = rng.normal(0, 20, n_rows)
-    wind_direction = (base_direction + direction_change) % 360
-
-    # Solar GHI: bell curve centered at noon, seasonal amplitude
-    max_ghi = 900 + 100 * np.sin(2 * np.pi * (day_of_year - 80) / 365)
-    solar_hour = hour_array - 12
-    daylight_half_span = 6  # hours from solar noon with nonzero GHI
-    ghi_pattern = np.where(
-        np.abs(solar_hour) < daylight_half_span,
-        max_ghi * (1 - (solar_hour / 8) ** 2),
-        0,
-    )
-    cloud_factor = rng.uniform(0.7, 1.0, n_rows)
-    ghi = np.clip(ghi_pattern * cloud_factor, 0, 1000)
-
-    # Temperature: seasonal + diurnal + noise
-    seasonal_temp = 15 + 12 * np.sin(2 * np.pi * (day_of_year - 80) / 365)
-    diurnal_temp = 5 * np.sin(2 * np.pi * (hour_array - 6) / 24)
-    temp_noise = rng.normal(0, 2, n_rows)
-    temperature = seasonal_temp + diurnal_temp + temp_noise
-
-    # Pressure: seasonal + noise
-    base_pressure = 1013
-    seasonal_pressure = 5 * np.sin(2 * np.pi * day_of_year / 365)
-    pressure_noise = rng.normal(0, 5, n_rows)
-    pressure = base_pressure + seasonal_pressure + pressure_noise
-
-    # Relative humidity: base - temp effect - ghi effect + noise
-    base_humidity = 65
-    temp_effect = -0.5 * (temperature - 15)
-    ghi_effect = -0.01 * ghi
-    humidity_noise = rng.normal(0, 10, n_rows)
-    relative_humidity = np.clip(
-        base_humidity + temp_effect + ghi_effect + humidity_noise,
-        20,
-        95,
-    )
-
-    result = (
-        df.select(["timestamp", "asset_id"])
-        .with_columns(
-            pl.Series("wind_speed_mps", wind_speed),
-            pl.Series("wind_direction_deg", wind_direction),
-            pl.Series("ghi", ghi),
-            pl.Series("temperature_c", temperature),
-            pl.Series("pressure_hpa", pressure),
-            pl.Series("relative_humidity", relative_humidity),
-        )
-        .sort(["timestamp", "asset_id"])
-    )
-
+    df = synthetic_weather(FLEET, start_date, end_date, random_seed=random_seed)
+    result = df.select(_RAW_WEATHER_COLUMNS)
     logger.info(
-        "Weather data generation completed: %d rows, %d assets",
-        len(result),
-        asset_count,
+        "Weather data completed: %d rows, %d assets", result.height, len(FLEET)
     )
     return result
 
@@ -174,13 +98,11 @@ def save_weather_parquet(
             df.select(pl.col("timestamp").dt.date().alias("date")).unique().sort("date")
         )
         logger.info("Saving %d daily weather files to %s", len(dates), output_dir)
-
         for (date_val,) in dates.iter_rows():
             date_str = date_val.isoformat()
             daily_df = df.filter(pl.col("timestamp").dt.date() == date_val)
             output_path = output_dir / f"weather_{date_str}.parquet"
             daily_df.write_parquet(output_path, compression="snappy")
-
         logger.info("Saved %d weather files", len(dates))
     else:
         output_path = output_dir / "weather_all.parquet"

--- a/tests/unit/test_dashboard_export.py
+++ b/tests/unit/test_dashboard_export.py
@@ -47,6 +47,7 @@ def _make_valid_mart_df(rows: int = _MIN_ROWS + 5) -> pl.DataFrame:
         {
             "ASSET_ID": [f"ASSET_{i:03d}" for i in range(rows)],
             "DATE": [f"2026-04-{(i % 28) + 1:02d}" for i in range(rows)],
+            "ASSET_TYPE": ["wind" for _ in range(rows)],
             "TOTAL_NET_GENERATION_MWH": [100.0 + i for i in range(rows)],
             "DAILY_CAPACITY_FACTOR": [0.4 for _ in range(rows)],
             "AVG_AVAILABILITY_PCT": [98.0 for _ in range(rows)],
@@ -60,6 +61,13 @@ def _make_valid_mart_df(rows: int = _MIN_ROWS + 5) -> pl.DataFrame:
             "AVG_GHI": [450.0 for _ in range(rows)],
             "AVG_TEMPERATURE_C": [18.5 for _ in range(rows)],
             "DATA_COMPLETENESS_PCT": [100.0 for _ in range(rows)],
+            # Technology-specific columns (null for wind in this fixture):
+            "AVG_SOC_PCT": [None for _ in range(rows)],
+            "TOTAL_CHARGE_MWH": [None for _ in range(rows)],
+            "TOTAL_DISCHARGE_MWH": [None for _ in range(rows)],
+            "TOTAL_FUEL_MMBTU": [None for _ in range(rows)],
+            "AVG_HEAT_RATE_BTU_KWH": [None for _ in range(rows)],
+            "TOTAL_CO2_TONNES": [None for _ in range(rows)],
             # Real mart column names (not the renamed data-contract names):
             "ASSET_CAPACITY_MW": [50.0 for _ in range(rows)],
             "ASSET_SIZE_CATEGORY": ["medium" for _ in range(rows)],
@@ -198,7 +206,7 @@ def test_build_writes_all_four_files(tmp_path: Path) -> None:
     assert result.metadata["weather_performance_bytes"] > 0
     assert result.metadata["assets_bytes"] > 0
     assert result.metadata["manifest_bytes"] > 0
-    assert result.metadata["schema_version"] == "1.0"
+    assert result.metadata["schema_version"] == "2.0"
 
     # All 4 files were written
     assert (export_dir / _DAILY_PERFORMANCE_FILE).exists()
@@ -231,7 +239,7 @@ def test_build_writes_all_four_files(tmp_path: Path) -> None:
     assert "date_range" in manifest
     assert "asset_count" in manifest
     assert "row_counts" in manifest
-    assert manifest["schema_version"] == "1.0"
+    assert manifest["schema_version"] == "2.0"
 
     # Connection closed
     mock_conn.close.assert_called_once()

--- a/tests/unit/test_generation_ingestion.py
+++ b/tests/unit/test_generation_ingestion.py
@@ -22,8 +22,8 @@ from weather_analytics.assets.ingestion.generation import (
     waga_generation_ingestion,
 )
 
-# 24 hours * 10 assets
-EXPECTED_DAILY_ROWS = 240
+# 24 hours * 12 fleet assets (4 wind, 4 solar, 2 battery, 2 gas)
+EXPECTED_DAILY_ROWS = 288
 
 
 @pytest.mark.unit

--- a/tests/unit/test_weather_ingestion.py
+++ b/tests/unit/test_weather_ingestion.py
@@ -24,8 +24,8 @@ from weather_analytics.assets.ingestion.weather import (
 )
 from weather_analytics.mock_data.generate_generation import ASSET_CONFIGS
 
-# 24 hours * 10 assets
-EXPECTED_DAILY_ROWS = 240
+# 24 hours * 12 fleet assets (4 wind, 4 solar, 2 battery, 2 gas)
+EXPECTED_DAILY_ROWS = 288
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary

Makes the **warehouse pipeline proper for all four technologies**, so the Snowflake path and the local dashboard path share one fleet (`mock_data.fleet.FLEET`, 12 assets) and emit the **identical v2.0 export schema**.

> **Stacked on #29** — depends on the `fleet.py` / `physics.py` / `simulate.py` modules introduced there. Review/merge #29 first.

### What changed

**Explicit `asset_type` (no more correlation inference)**
- Generators emit `asset_type` + battery/gas columns (SOC, charge/discharge, fuel, heat rate, CO₂); it flows RAW → staging → intermediate → marts.
- `mart_asset_weather_performance.inferred_asset_type` is now the explicit type; `accepted_values` widened to `['wind','solar','battery','gas']`.

**Type-branched scoring** in the weather mart:
- wind/solar → weather-adjusted actual-vs-expected ratio (unchanged)
- battery → realized round-trip efficiency (discharge / charge)
- gas → heat-rate efficiency (best / realized heat rate)

**Battery is a net load** — negative `net_generation_mwh` / capacity factor. Every non-negativity range test (RAW source, staging, daily mart contract, and `waga_generation_value_range_check`) is scoped `where asset_type <> 'battery'`.

**Correctness fixes**
- Ingestion seeds are deterministic per partition date (was `int(time.time())`), restoring **merge idempotency** and weather/generation consistency.
- Fixed latent wrong-column bugs in both value-range asset checks (`wind_speed`→`wind_speed_mps`, `generation_mwh`→`net_generation_mwh`).
- `dashboard_export` projects the new columns, sources `asset_type` from the daily mart, and stamps `schema_version: 2.0` + `asset_type_counts`.

### Verification

- `dbt parse` builds the manifest cleanly (SQL, refs, macros valid).
- 146 unit tests pass (ingestion row counts, export schema/columns, etc.); ruff clean.
- **Not runnable here:** dbt contract enforcement and range tests execute against Snowflake. A live `dbt build` + Dagster materialization is the final verification step. Watch the contracted marts and the `where asset_type <> 'battery'` range tests on that run.