### PR TITLE
style(cockpit): retune dashboard palette to match afk-cockpit

### DIFF
--- a/src/weather_analytics/cockpit/charts.py
+++ b/src/weather_analytics/cockpit/charts.py
@@ -18,17 +18,17 @@ from weather_analytics.cockpit.data import DailyRow, Dataset, WeatherRow
 # Technology series colors — echo the portfolio's data-viz palette (green/gold)
 # and extend it with distinct, light-theme-friendly hues for storage and gas.
 TYPE_COLORS: dict[str, str] = {
-    "wind": "#2f6f5f",
-    "solar": "#d4a12e",
-    "battery": "#3f7cac",
-    "gas": "#9c5b3b",
-    "unknown": "#8a8f98",
+    "wind": "#4f7d63",
+    "solar": "#b3873f",
+    "battery": "#8fa8c4",
+    "gas": "#9e6c52",
+    "unknown": "#a0a0a0",
 }
 
 _RENEWABLE = ("wind", "solar")
 _CF_TYPES = ("wind", "solar", "gas")  # battery CF is not meaningful
-_PRIMARY = "#2f6f5f"  # portfolio data-viz green
-_SECONDARY = "#b0872f"  # portfolio data-viz gold
+_PRIMARY = "#4f7d63"  # afk-cockpit sage green
+_SECONDARY = "#b3873f"  # afk-cockpit amber
 
 
 def type_color(asset_type: str) -> str:

--- a/src/weather_analytics/cockpit/static/app.js
+++ b/src/weather_analytics/cockpit/static/app.js
@@ -13,10 +13,10 @@
   var weather = D.weather || [];
 
   var TYPE_COLORS = {
-    wind: "#2f6f5f", solar: "#d4a12e", battery: "#3f7cac",
-    gas: "#9c5b3b", unknown: "#8a8f98",
+    wind: "#4f7d63", solar: "#b3873f", battery: "#8fa8c4",
+    gas: "#9e6c52", unknown: "#a0a0a0",
   };
-  var PRIMARY = "#2f6f5f", GOLD = "#b0872f";
+  var PRIMARY = "#4f7d63", GOLD = "#b3873f";
   var RENEWABLE = { wind: 1, solar: 1 };
   var CF_TYPES = { wind: 1, solar: 1, gas: 1 };
 

--- a/src/weather_analytics/cockpit/templates/index.html.j2
+++ b/src/weather_analytics/cockpit/templates/index.html.j2
@@ -30,14 +30,14 @@
   :root {
     --white: #fff; --gray-50: #f9f9f9; --gray-100: #f0f0f0; --gray-200: #e0e0e0;
     --gray-500: #666; --gray-600: #555; --gray-800: #353535;
-    --accent-blue: rgb(235, 241, 248); --accent-soft: rgba(235, 241, 248, 0.5);
-    --data-green: #2f6f5f; --data-gold: #b0872f;
-    --wind: #2f6f5f; --solar: #d4a12e; --battery: #3f7cac; --gas: #9c5b3b;
+    --accent-blue: rgb(235, 241, 248); --accent-soft: rgba(235, 241, 248, 0.55);
+    --data-green: #4f7d63; --data-gold: #b3873f;
+    --wind: #4f7d63; --solar: #b3873f; --battery: #8fa8c4; --gas: #9e6c52;
     --bg: var(--gray-50); --card: var(--white);
     --ink: var(--gray-800); --muted: var(--gray-500); --line: var(--gray-200);
     --radius-card: 10px; --radius-sm: 8px; --radius-pill: 2rem;
-    --shadow-card: 0 4px 6px rgba(0, 0, 0, 0.08);
-    --shadow-hover: 0 8px 12px rgba(0, 0, 0, 0.14);
+    --shadow-card: 0 2px 10px rgba(0, 0, 0, 0.06);
+    --shadow-hover: 0 6px 16px rgba(0, 0, 0, 0.10);
     --transition: 300ms ease;
     --font: 'Poppins', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
   }
@@ -96,9 +96,9 @@
     align-items: center; gap: 10px; margin: 8px 0; }
   .hbar-label { font-size: 0.85rem; overflow: hidden; text-overflow: ellipsis;
     white-space: nowrap; }
-  .hbar-track { background: var(--gray-100); border-radius: 5px; height: 12px;
+  .hbar-track { background: #efefef; border-radius: 2rem; height: 10px;
     overflow: hidden; }
-  .hbar-fill { height: 100%; border-radius: 5px; transition: width var(--transition); }
+  .hbar-fill { height: 100%; border-radius: 2rem; transition: width var(--transition); }
   .hbar-value { text-align: right; color: var(--gray-600);
     font-variant-numeric: tabular-nums; font-size: 0.85rem; }
   .nodata { color: var(--muted); font-style: italic; padding: 8px 0; }


### PR DESCRIPTION
Swaps the saturated technology colors for afk-cockpit's muted, refined palette — **sage green** (wind), **soft amber** (solar), **dusty blue** (battery), **terracotta** (gas) — with softer card shadows and pill-shaped bar tracks to match.

Updated consistently in all three color sites: template CSS `:root`, `charts.py` (`TYPE_COLORS`/`_PRIMARY`/`_SECONDARY`), and `app.js`. Cosmetic only; ruff clean, 146 unit + 21 cockpit tests pass; rebuilt + previewed.